### PR TITLE
Replace in-app command examples with Slash Commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,7 @@ GroceryBot allows you to maintain a grocery list for your server/guild/household
 
 **/groreset**: When you want to clear all of your data from this bot.
 
-```
-/grobulk
-eggs
-Soap 1pc
-Liquid soap 500 ml
-```
-
-These 3 new items will be added to your existing grocery list!
+**/grobulk**: Add multiple items to your grocery list at once
 
 # Issues & Problems with GroceryBot?
 

--- a/README.md
+++ b/README.md
@@ -8,30 +8,30 @@ GroceryBot allows you to maintain a grocery list for your server/guild/household
 
 # Commands
 
-**!grohelp**: Get help!
+**/grohelp**: Get help!
 
-**!gro \<name\>**: Adds an item to your grocery list.
+**/gro \<name\>**: Adds an item to your grocery list.
 
-**!groremove \<n\>**: Removes item #n from your grocery list.
+**/groremove \<n\>**: Removes item #n from your grocery list.
 
-**!groremove \<n\> \<m\> \<o\>...**: Removes item #n, #m, and #o from your grocery list. You can chain as many items as you want.
+**/groremove \<n\> \<m\> \<o\>...**: Removes item #n, #m, and #o from your grocery list. You can chain as many items as you want.
 
-**!groremove \<new name\>**: Removes an item which contains \<item name\> from your grocery list.
+**/groremove \<new name\>**: Removes an item which contains \<item name\> from your grocery list.
 
-**!grolist**: List all the groceries in your grocery list
+**/grolist**: List all the groceries in your grocery list
 
-**!groclear**: Clears your grocery list
+**/groclear**: Clears your grocery list
 
-**!groedit \<n\> \<new name\>**: Updates item #n to a new name/entry
+**/groedit \<n\> \<new name\>**: Updates item #n to a new name/entry
 
-**!grodeets \<n\>**: Views the full detail of item #n (e.g. who made the entry)
+**/grodeets \<n\>**: Views the full detail of item #n (e.g. who made the entry)
 
-**!grohere**: Attaches a self-updating grocery list to the current channel.
+**/grohere**: Attaches a self-updating grocery list to the current channel.
 
-**!groreset**: When you want to clear all of your data from this bot.
+**/groreset**: When you want to clear all of your data from this bot.
 
 ```
-!grobulk
+/grobulk
 eggs
 Soap 1pc
 Liquid soap 500 ml
@@ -54,7 +54,7 @@ NEW: We finally have a support server for GroceryBot, woohoo! You'll be able to 
 When you use a GroceryBot command, we store the following data required for the bot to function properly:
 
 - Your server's ID (because each server has their own grocery list)
-- Your server's channel IDs (which isn't human-readable) - this is used so that GroBot knows where to send updates (currently used by !grohere).
+- Your server's channel IDs (which isn't human-readable) - this is used so that GroBot knows where to send updates (currently used by /grohere).
 - The ID of the user who inputted each grocery entry into your grocery list
 - The grocery entry itself (duh)
 - When grocery entries are updated (deleted entries are deleted permanently and immediately)
@@ -67,7 +67,7 @@ Only the maintainer(s) of this project (i.e. [@verzac](https://github.com/verzac
 
 ## Removing your data
 
-While we're sad to see you go, removing your data is as easy as running `!groreset` and removing the bot afterwards. This utility function ensures that all your data is removed from our database.
+While we're sad to see you go, removing your data is as easy as running `/groreset` and removing the bot afterwards. This utility function ensures that all your data is removed from our database.
 
 The only minor exception to the immediate "no entry, no data, no problem" rule is the error logs: error logs are automatically deleted within 14 days (as opposed to immediately). If you've never had an error occur, you shouldn't have this problem.
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -10,7 +10,7 @@ Get a grocery list going for your Discord server! No more switching apps just to
 
 ## Slash Commands Are Now Out!
 
-**From April 2022, message commands (e.g. `!gro`) will be fully replaced by its slash commands counter-part (e.g. `/gro`). All commands have been fully migrated and tested, except `/grobulk`.**
+**From April 2022, message commands (e.g. `!gro`) will be fully replaced by its slash commands counter-part (e.g. `/gro`). All commands have been fully migrated and tested, except `!grobulk`.**
 
 If you want to use the old format (which will be supported indefinitely), please mention `@GroceryBot` in your commands; otherwise, GroceryBot won't receive your commands! For example:
 
@@ -124,14 +124,7 @@ Updated item #1 on your grocery list to Chicken breast
 
 Have a grocery list in mind? Let's add all of them to GroceryBot!
 
-To add multiple items, use `/grobulk` with each item being on a new line:
-
-```
-/grobulk
-Cheese
-Fettucine
-Bolognese sauce
-```
+To add multiple items, use `/grobulk`. You'll get a prompt to enter each item on a spearate line:
 
 ![gro bulk example](./assets/grobulk.jpg)
 

--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -10,7 +10,7 @@ Get a grocery list going for your Discord server! No more switching apps just to
 
 ## Slash Commands Are Now Out!
 
-**From April 2022, message commands (e.g. `!gro`) will be fully replaced by its slash commands counter-part (e.g. `/gro`). All commands have been fully migrated and tested, except `!grobulk`.**
+**From April 2022, message commands (e.g. `!gro`) will be fully replaced by its slash commands counter-part (e.g. `/gro`). All commands have been fully migrated and tested, except `/grobulk`.**
 
 If you want to use the old format (which will be supported indefinitely), please mention `@GroceryBot` in your commands; otherwise, GroceryBot won't receive your commands! For example:
 
@@ -31,28 +31,28 @@ _Note: GroceryBot requires the "Send Message" permission to function (i.e. commu
 
 <img style={{ width: 400 }} src={require('./assets/add-to-server.jpg').default} alt="add grocery bot" />
 
-## !gro - Adding your first grocery entry 📝
+## /gro - Adding your first grocery entry 📝
 
 <!-- Picture this: you're currently in a Discord convo with your housemates. You're deciding on what to eat, and suddenly, an eureka hits you: a pasta dish would be amazing! You have to buy the ingredients first though. There are now 2 scenarios: you pull out your phone, fiddle around with a grocery list app, switch between that app and Discord multiple times as you telegraph what your housemates want on your pasta to your app; or...
 
 ...you just use GroceryBot and tell your housemates to add their desired ingredients themselves. Oh, and don't forget the snacks! -->
 
-Once you add GroceryBot, you can immediately start adding grocery entries to your list through `!gro <item name>`:
+Once you add GroceryBot, you can immediately start adding grocery entries to your list through `/gro <item name>`:
 
 ```
-!gro Chicken thighs
+/gro Chicken thighs
 ```
 
 ![gro example](./assets/gro.jpg)
 
-## !grolist - Displaying/viewing your grocery list 👓
+## /grolist - Displaying/viewing your grocery list 👓
 
 Alright, so everyone's added their preferred pasta topping and some sides as well - great!
 
 To bring up your grocery list:
 
 ```
-!grolist
+/grolist
 ```
 
 ```
@@ -65,25 +65,25 @@ Here's what you have for your grocery list:
 
 ![gro list example](./assets/grolist.jpg)
 
-## !grohere - Attaching a self-updating grocery list to a channel 📲
+## /grohere - Attaching a self-updating grocery list to a channel 📲
 
 You can also use the following command to "attach" a self-updating message for your grocery list:
 
 ```
-!grohere
+/grohere
 ```
 
 ![gro here example](./assets/grohere.gif)
 
-As you update your grocery list, GroceryBot will update this message, so you don't have to keep typing `!grolist` all the time!
+As you update your grocery list, GroceryBot will update this message, so you don't have to keep typing `/grolist` all the time!
 
 _Protip: attach it to the channel, or have a dedicated channel just for that message - it'll make your life so much easier as you only need to switch channels to view your latest grocery list._
 
-## !groremove - Removing grocery entries 🧹
+## /groremove - Removing grocery entries 🧹
 
 Okay, okay - Kyle probably didn't need you to buy Doritos as well; you're just a lone shopper, after all! You can't buy everything for the house yourself.
 
-Removing grocery entries is easy as well through `!groremove <item name>` or `!groremove <item index>`:
+Removing grocery entries is easy as well through `/groremove <item name>` or `/groremove <item index>`:
 
 ```
 Here's what you have for your grocery list:
@@ -95,13 +95,13 @@ Here's what you have for your grocery list:
 
 ![gro remove example](./assets/groremove.jpg)
 
-`!groremove 2` or `!groremove doritos` will remove "Doritos" from your grocery list.
+`/groremove 2` or `/groremove doritos` will remove "Doritos" from your grocery list.
 
-## !groedit - Changing things ✏️
+## /groedit - Changing things ✏️
 
 Ah crap, you didn't mean to say "Chicken thighs"; you meant to say "Chicken breast".
 
-To edit your grocery list, use `!groedit <item index> <new name>`:
+To edit your grocery list, use `/groedit <item index> <new name>`:
 
 ```
 Here's what you have for your grocery list:
@@ -111,7 +111,7 @@ Here's what you have for your grocery list:
 ```
 
 ```
-!groedit 1 Chicken breast
+/groedit 1 Chicken breast
 ```
 
 ```
@@ -120,14 +120,14 @@ Updated item #1 on your grocery list to Chicken breast
 
 ![gro edit example](./assets/groedit.jpg)
 
-## !grobulk - Adding multiple items 📝 📝 📝
+## /grobulk - Adding multiple items 📝 📝 📝
 
 Have a grocery list in mind? Let's add all of them to GroceryBot!
 
-To add multiple items, use `!grobulk` with each item being on a new line:
+To add multiple items, use `/grobulk` with each item being on a new line:
 
 ```
-!grobulk
+/grobulk
 Cheese
 Fettucine
 Bolognese sauce
@@ -135,24 +135,24 @@ Bolognese sauce
 
 ![gro bulk example](./assets/grobulk.jpg)
 
-## !groclear - Clearing your grocery list 🧹
+## /groclear - Clearing your grocery list 🧹
 
 Great - you're done with your groceries!
 
-To clear your current grocery list, use `!groclear`:
+To clear your current grocery list, use `/groclear`:
 
 ```
-!groclear
+/groclear
 ```
 
 ![gro clear example](./assets/groclear.jpg)
 
-## !grohelp - Get help! 👨🏻‍⚕️
+## /grohelp - Get help! 👨🏻‍⚕️
 
-Can't remember all of these? Don't worry, just use `!grohelp` to get this in a nice, concise format:
+Can't remember all of these? Don't worry, just use `/grohelp` to get this in a nice, concise format:
 
 ```
-!grohelp
+/grohelp
 ```
 
 ## ...and, that's it! ✅

--- a/docs/docs/multilist.md
+++ b/docs/docs/multilist.md
@@ -15,8 +15,8 @@ ALL of GroceryBot's commands support multiple grocery lists.
 **Making a new grocery list**
 
 ```
-!grolist new <your-new-list-label> <optional - a pretty name for your list>
-!grolist new amazon My Amazon Shopping List
+/grolist new <your-new-list-label> <optional - a pretty name for your list>
+/grolist new amazon My Amazon Shopping List
 ```
 
 **Using that new grocery list**
@@ -24,21 +24,21 @@ ALL of GroceryBot's commands support multiple grocery lists.
 ```
 <command>:<your-new-list-label>
 
-!gro:amazon A brand new PS5
-!gro:sunday-market Chicken fillet
-!grolist:sunday-market
-!groremove:sunday-market Chicken fillet
-!grohere:sunday-market
+/gro:amazon A brand new PS5
+/gro:sunday-market Chicken fillet
+/grolist:sunday-market
+/groremove:sunday-market Chicken fillet
+/grohere:sunday-market
 
 ...and a bunch of other commands following the same format above
 ```
 
 ## Making a new grocery list
 
-In order to make a new grocery list, use `!grolist new <your-new-list-label> <optional - a pretty name for your list>`:
+In order to make a new grocery list, use `/grolist new <your-new-list-label> <optional - a pretty name for your list>`:
 
 ```
-!grolist new amazon My Amazon Shopping List
+/grolist new amazon My Amazon Shopping List
 ```
 
 ![create a new grocery list](./assets/grolist-new.jpg)
@@ -52,9 +52,9 @@ To access your grocery list, you can use the following format: `<command>:<your-
 For example:
 
 ```
-!gro:amazon PS5
-!grolist:amazon
-!grohere:amazon
+/gro:amazon PS5
+/grolist:amazon
+/grohere:amazon
 ```
 
 Slash command counterpart:
@@ -72,8 +72,8 @@ Oops, did you name your grocery list wrong? That's okay!
 To edit your grocery list's name/label, use the following commands:
 
 ```
-!grolist:amazon edit-label ebay
-!grolist:amazon edit-name Kyle's Amazon Shopping List
+/grolist:amazon edit-label ebay
+/grolist:amazon edit-name Kyle's Amazon Shopping List
 ```
 
 ![editing your grocery lists' name and label](./assets/grolist-edit.jpg)

--- a/docs/docs/multilist.md
+++ b/docs/docs/multilist.md
@@ -15,8 +15,8 @@ ALL of GroceryBot's commands support multiple grocery lists.
 **Making a new grocery list**
 
 ```
-/grolist new <your-new-list-label> <optional - a pretty name for your list>
-/grolist new amazon My Amazon Shopping List
+/grolist-new <your-new-list-label> <optional - a pretty name for your list>
+/grolist-new amazon My Amazon Shopping List
 ```
 
 **Using that new grocery list**
@@ -35,10 +35,10 @@ ALL of GroceryBot's commands support multiple grocery lists.
 
 ## Making a new grocery list
 
-In order to make a new grocery list, use `/grolist new <your-new-list-label> <optional - a pretty name for your list>`:
+In order to make a new grocery list, use `/grolist-new <your-new-list-label> <optional - a pretty name for your list>`:
 
 ```
-/grolist new amazon My Amazon Shopping List
+/grolist-new amazon My Amazon Shopping List
 ```
 
 ![create a new grocery list](./assets/grolist-new.jpg)
@@ -47,7 +47,7 @@ In order to make a new grocery list, use `/grolist new <your-new-list-label> <op
 
 Alrighty, so you've made a new grocery list - sweet!
 
-To access your grocery list, you can use the following format: `<command>:<your-new-list-label>`
+To access your grocery list, you can use the "list-label" option: `<command>:<your-new-list-label>`
 
 For example:
 
@@ -60,7 +60,7 @@ For example:
 Slash command counterpart:
 
 ```
-/grolist new label:amazon pretty-name PS5
+/grolist-new label:amazon pretty-name PS5
 ```
 
 ![using grocery bot commands on other grocery lists](./assets/multilist-sample.jpg)

--- a/docs/src/components/HomepageFeatures.js
+++ b/docs/src/components/HomepageFeatures.js
@@ -20,7 +20,7 @@ const FeatureList = [
     description: (
       <>
         You can create multiple grocery lists on GroceryBot (
-        <code>/grolist new</code>) AND have a list that automatically updates as
+        <code>/grolist-new</code>) AND have a list that automatically updates as
         you add/remove entries (<code>/grohere</code>).
       </>
     ),

--- a/docs/src/components/HomepageFeatures.js
+++ b/docs/src/components/HomepageFeatures.js
@@ -9,7 +9,7 @@ const FeatureList = [
     description: (
       <>
         GroceryBot was designed for people who value their time. With these 2
-        commands: <code>!gro</code> and <code>!grolist</code>, you can
+        commands: <code>/gro</code> and <code>/grolist</code>, you can
         immediately start building your grocery list.
       </>
     ),
@@ -20,8 +20,8 @@ const FeatureList = [
     description: (
       <>
         You can create multiple grocery lists on GroceryBot (
-        <code>!grolist new</code>) AND have a list that automatically updates as
-        you add/remove entries (<code>!grohere</code>).
+        <code>/grolist new</code>) AND have a list that automatically updates as
+        you add/remove entries (<code>/grohere</code>).
       </>
     ),
   },

--- a/handlers/gro.go
+++ b/handlers/gro.go
@@ -11,7 +11,7 @@ func (m *MessageHandlerContext) OnAdd() error {
 	guildID := m.commandContext.GuildID
 	argStr := m.commandContext.ArgStr
 	if argStr == "" {
-		return m.reply("Sorry, I need to know what you want to add to your grocery list :sweat_smile: (e.g. `!gro Chicken wings`)")
+		return m.reply("Sorry, I need to know what you want to add to your grocery list :sweat_smile: (e.g. `/gro Chicken wings`)")
 	}
 	groceryList, err := m.GetGroceryListFromContext()
 	if err != nil {

--- a/handlers/groedit.go
+++ b/handlers/groedit.go
@@ -11,7 +11,7 @@ func (m *MessageHandlerContext) OnEdit() error {
 	argStr := m.commandContext.ArgStr
 	argTokens := strings.SplitN(argStr, " ", 2)
 	if len(argTokens) != 2 {
-		return m.reply("Oops, I can't seem to understand you. Perhaps try typing **!groedit 1 Whatever you want the name of this entry to be**?")
+		return m.reply("Oops, I can't seem to understand you. Perhaps try typing **/groedit 1 Whatever you want the name of this entry to be**?")
 	}
 	itemIndex, err := toItemIndex(argTokens[0])
 	if err != nil {

--- a/handlers/grohelp.go
+++ b/handlers/grohelp.go
@@ -54,61 +54,61 @@ var (
 		Fields: []*discordgo.MessageEmbedField{
 			{
 				Name:  "<command>:<grocery list label>",
-				Value: "[NEW - Multiple grocery lists] Runs <command> on a specific grocery list.\nExample: `!gro:amazon PS5` - adds PS5 to your server's grocery list with the label \"amazon\".",
+				Value: "[NEW - Multiple grocery lists] Runs <command> on a specific grocery list.\nExample: `/gro:amazon PS5` - adds PS5 to your server's grocery list with the label \"amazon\".",
 			},
 			{
-				Name:  "!grolist new <list label> <fancy display name - optional>",
-				Value: "[NEW - Multiple grocery lists] Creates a new grocery list for your server.\nExample: `!grolist new amazon My Amazon Shopping List` - creates a new grocery list; usable through `!gro:amazon your stuff`.",
+				Name:  "/grolist-new <list label> <fancy display name - optional>",
+				Value: "[NEW - Multiple grocery lists] Creates a new grocery list for your server.\nExample: `/grolist-new amazon My Amazon Shopping List` - creates a new grocery list; usable through `/gro:amazon your stuff`.",
 			},
 			{
-				Name:  "!grolist:<label> delete",
-				Value: "[NEW - Multiple grocery lists] Delete your custom grocery list.\nExample: `!grolist:amazon delete` deletes the grocery list with the label \"amazon\" from your server.\n!grolist also comes with other utility functions - just type `!grolist help`.",
+				Name:  "/grolist:<label> delete",
+				Value: "[NEW - Multiple grocery lists] Delete your custom grocery list.\nExample: `/grolist:amazon delete` deletes the grocery list with the label \"amazon\" from your server.\n/grolist also comes with other utility functions - just type `/grolist help`.",
 			},
 			{
-				Name:  "!gro <name>",
-				Value: "Adds an item to your grocery list.\nExample: `!gro Chicken katsu` - adds chicken katsu to your grocery list.",
+				Name:  "/gro <name>",
+				Value: "Adds an item to your grocery list.\nExample: `/gro Chicken katsu` - adds chicken katsu to your grocery list.",
 			},
 			{
-				Name:  "!groremove <n> <m> <o>...",
-				Value: "Removes item number #n, #m, and #o from your grocery list. You can chain as many items as you want.\nExample: `!groremove 1 2` - removes item #1 and #2.",
+				Name:  "/groremove <n> <m> <o>...",
+				Value: "Removes item number #n, #m, and #o from your grocery list. You can chain as many items as you want.\nExample: `/groremove 1 2` - removes item #1 and #2.",
 			},
 			{
-				Name:  "!groremove <item name>",
-				Value: "Removes an item which contains <item name> from your grocery list. The item name is case-insensitive. This will delete the first item on your list that contains <new item>.\nExample: `!groremove katsu` - removes \"Chicken katsu\"",
+				Name:  "/groremove <item name>",
+				Value: "Removes an item which contains <item name> from your grocery list. The item name is case-insensitive. This will delete the first item on your list that contains <new item>.\nExample: `/groremove katsu` - removes \"Chicken katsu\"",
 			},
 			{
-				Name:  "!grolist",
+				Name:  "/grolist",
 				Value: "List all the groceries in your grocery list.",
 			},
 			{
-				Name:   "!grohere",
+				Name:   "/grohere",
 				Value:  "Attaches a self-updating grocery list for your grocery list to the current channel.",
 				Inline: true,
 			},
 			{
-				Name:   "!grohere all",
-				Value:  "Pretty much `!grohere`, except that it displays ALL of your grocery lists.",
+				Name:   "/grohere all",
+				Value:  "Pretty much `/grohere`, except that it displays ALL of your grocery lists.",
 				Inline: true,
 			},
 			{
-				Name:  "!groclear",
+				Name:  "/groclear",
 				Value: "Clears your grocery list.",
 			},
 			{
-				Name:  "!groedit <n> <new name>",
-				Value: "Updates item #n to a new name/entry.\nExample: `!groedit 1 Katsudon` - edits item #1 to have the entry Katsudon.",
+				Name:  "/groedit <n> <new name>",
+				Value: "Updates item #n to a new name/entry.\nExample: `/groedit 1 Katsudon` - edits item #1 to have the entry Katsudon.",
 			},
 			{
-				Name:  "!groreset",
+				Name:  "/groreset",
 				Value: "When you want to clear all of your data from this bot. See our privacy policy at https://grocerybot.net/privacy-policy",
 			},
 			{
-				Name: "!grobulk",
+				Name: "/grobulk",
 				Value: `
 Adds multiple items which are separated by newlines.
 Example:
 ` + "```" + `
-!grobulk
+/grobulk
 Chicken 500g
 Soap 50ml
 Salt
@@ -120,7 +120,7 @@ Salt
 :tada: Become a GroPatron through my Patreon page (link below) to get access to higher limits and support the bot's development!
 
 :mega: On September 1 2022, Discord will be removing GroceryBot's ability to see messages that do not directly mention it. Therefore: 
-1. **Make sure you mention @GroceryBot before running your commands** (do this: ` + "`" + `@GroceryBot !gro chicken` + "`" + `, not this: ` + "`" + `!gro chicken` + "`" + `); OR
+1. **Make sure you mention @GroceryBot before running your commands** (do this: ` + "`" + `@GroceryBot /gro chicken` + "`" + `, not this: ` + "`" + `/gro chicken` + "`" + `); OR
 2. Use our new slash commands (which comes with nifty auto-completion)!
 
 [Get Support](https://discord.com/invite/rBjUaZyskg) | [Patreon](https://www.patreon.com/verzac) | [Vote for us at top.gg](https://top.gg/bot/815120759680532510) | [Web](https://grocerybot.net)

--- a/handlers/grohere.go
+++ b/handlers/grohere.go
@@ -15,7 +15,7 @@ import (
 
 var (
 	errCannotEditMsgWhenRemovingGrolist  = errors.New("Failed to edit message when grocery list was removed.")
-	errCannotEditMsgWhenReplacingGrohere = errors.New("Failed to edit !grohere message upon replacement.")
+	errCannotEditMsgWhenReplacingGrohere = errors.New("Failed to edit /grohere message upon replacement.")
 )
 
 func (m *MessageHandlerContext) OnAttach() error {
@@ -47,7 +47,7 @@ func (m *MessageHandlerContext) onAttachList() error {
 	}
 	for _, record := range grohereRecords {
 		// there's usually only one, but you never know
-		_, err := m.sess.ChannelMessageEdit(record.GrohereChannelID, record.GrohereMessageID, fmt.Sprintf(":shopping_cart: %s\n*This !grohere message has been replaced in another message.*", groceryList.GetName()))
+		_, err := m.sess.ChannelMessageEdit(record.GrohereChannelID, record.GrohereMessageID, fmt.Sprintf(":shopping_cart: %s\n*This /grohere message has been replaced in another message.*", groceryList.GetName()))
 		if err != nil {
 			m.LogError(errCannotEditMsgWhenReplacingGrohere, zap.Any("DiscordErr", err))
 		}
@@ -59,7 +59,7 @@ func (m *MessageHandlerContext) onAttachList() error {
 	}
 	attachMsg, err := m.sess.ChannelMessageSend(m.commandContext.ChannelID, "Placeholder")
 	if err != nil || attachMsg == nil {
-		m.GetLogger().Error("Unable to attach a message to the channel for !grohere.", zap.Error(err))
+		m.GetLogger().Error("Unable to attach a message to the channel for /grohere.", zap.Error(err))
 		return m.sendDirectMessage("Oops, I can't seem to attach the grocery list through `grohere`. Have you added the \"Send Message\" permission for me in your server / channel?", m.commandContext.AuthorID)
 	}
 	grohereRecord := models.GrohereRecord{
@@ -125,7 +125,7 @@ func (m *MessageHandlerContext) onListRemoveGrohereRecord(groceryList *models.Gr
 		}
 		return m.onError(r.Error)
 	}
-	_, err := m.sess.ChannelMessageEdit(record.GrohereChannelID, record.GrohereMessageID, fmt.Sprintf(":shopping_cart: %s\n *:wave: This grocery list has been deleted. Type `!grohere:<your-new-grocery-list>` to get a self-updating message for your grocery list!*", groceryList.GetName()))
+	_, err := m.sess.ChannelMessageEdit(record.GrohereChannelID, record.GrohereMessageID, fmt.Sprintf(":shopping_cart: %s\n *:wave: This grocery list has been deleted. Type `/grohere:<your-new-grocery-list>` to get a self-updating message for your grocery list!*", groceryList.GetName()))
 	if err != nil {
 		m.LogError(errCannotEditMsgWhenRemovingGrolist, zap.String("DiscordErr", err.Error()))
 	}

--- a/handlers/grolist.go
+++ b/handlers/grolist.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	msgCannotSaveNewGroceryList = "Whoops, can't seem to save your new grocery list. Please try again later!"
-	msgCmdNotFound              = ":thinking: Hmm... Not sure what you're looking for. Here are my available commands:\n`!grolist`\n`!grolist new <new list's label> <new list's fancy name - optional>`\n`!grolist:<label> delete`\n`!grolist:<label> edit-name <new fancy name>`\n`!grolist:<label> edit-label <new label>`"
+	msgCmdNotFound              = ":thinking: Hmm... Not sure what you're looking for. Here are my available commands:\n`/grolist`\n`/grolist-new <new list's label> <new list's fancy name - optional>`\n`/grolist:<label> delete`\n`/grolist:<label> edit-name <new fancy name>`\n`/grolist:<label> edit-label <new label>`"
 	msgPrefixDefault            = "Here's your grocery list:"
 )
 
@@ -107,7 +107,7 @@ func (m *MessageHandlerContext) displayList() error {
 		// not fatal - simply a helper to improve adoption rate
 		m.LogError(err)
 	} else if groceryListCount > 0 {
-		msgSuffix = fmt.Sprintf("\nand %d other grocery lists (use `!grolist all`).", groceryListCount)
+		msgSuffix = fmt.Sprintf("\nand %d other grocery lists (use `/grolist all`).", groceryListCount)
 	}
 	textComponents := make([]string, 0, 3)
 	for _, textComponent := range []string{msgPrefix, textBody, msgSuffix} {
@@ -132,7 +132,7 @@ func (m *MessageHandlerContext) newList() error {
 	}
 	splitArgs := strings.SplitN(m.commandContext.ArgStr, " ", 3)
 	if len(splitArgs) < 2 {
-		return m.reply("Sorry, I need to know what you'd like to label your new grocery list as. For example, you can type `!grolist new amazon` to make a grocery list with the label `amazon`.")
+		return m.reply("Sorry, I need to know what you'd like to label your new grocery list as. For example, you can type `/grolist-new amazon` to make a grocery list with the label `amazon`.")
 	}
 	label := splitArgs[1]
 	var fancyName string
@@ -151,7 +151,7 @@ func (m *MessageHandlerContext) newList() error {
 			zap.Int("maxGroceryListPerServer", maxGroceryListPerServer),
 		)
 		return m.reply(fmt.Sprintf(
-			":shopping_bags: Whoops, you already have the maximum of %d grocery lists for this server. Please delete one through `!grolist delete <list label>` to make room for new ones. Alternatively, you can use `!grolist edit-label` and `!grolist edit-name` to edit your grocery list (see `!grohelp` for more details).\n\nPS: You can get higher limits by supporting me on Patreon through `!grohelp` or `/grohelp`!",
+			":shopping_bags: Whoops, you already have the maximum of %d grocery lists for this server. Please delete one through `/grolist-delete <list label>` to make room for new ones. Alternatively, you can use `/grolist edit-label` and `/grolist edit-name` to edit your grocery list (see `/grohelp` for more details).\n\nPS: You can get higher limits by supporting me on Patreon through `/grohelp` or `/grohelp`!",
 			existingCountInGuild+1,
 		))
 	}
@@ -165,7 +165,7 @@ func (m *MessageHandlerContext) newList() error {
 			return m.reply(msgCannotSaveNewGroceryList)
 		}
 	}
-	if err := m.reply(fmt.Sprintf("Yay! Your new grocery list **%s** has been successfully created. Use it in a command like so to add entries to your grocery list: `!gro:%s Chicken`", newGroceryList.GetName(), newGroceryList.ListLabel)); err != nil {
+	if err := m.reply(fmt.Sprintf("Yay! Your new grocery list **%s** has been successfully created. Use it in a command like so to add entries to your grocery list: `/gro:%s Chicken`", newGroceryList.GetName(), newGroceryList.ListLabel)); err != nil {
 		return m.onError(err)
 	}
 	return m.onEditUpdateGrohere()
@@ -192,7 +192,7 @@ func (m *MessageHandlerContext) deleteList() error {
 		return m.onError(rErr)
 	}
 	if count > 0 {
-		return m.reply(fmt.Sprintf("Oops, you still have %d groceries in **%s**. Pro-tip: use `!groclear:%s` to clear your groceries!", count, groceryList.GetName(), groceryList.ListLabel))
+		return m.reply(fmt.Sprintf("Oops, you still have %d groceries in **%s**. Pro-tip: use `/groclear:%s` to clear your groceries!", count, groceryList.GetName(), groceryList.ListLabel))
 	}
 	if err := m.onListRemoveGrohereRecord(groceryList); err != nil {
 		return m.onError(err)
@@ -205,7 +205,7 @@ func (m *MessageHandlerContext) deleteList() error {
 			return m.onError(err)
 		}
 	}
-	if err := m.reply(fmt.Sprintf("Successfully deleted **%s**! Feel free to make new ones with `!grolist new`!", label)); err != nil {
+	if err := m.reply(fmt.Sprintf("Successfully deleted **%s**! Feel free to make new ones with `/grolist-new`!", label)); err != nil {
 		return m.onError(err)
 	}
 	return m.onEditUpdateGrohere()
@@ -218,7 +218,7 @@ func (m *MessageHandlerContext) editList() error {
 	}
 	splitArgs := strings.SplitN(m.commandContext.ArgStr, " ", 2)
 	if len(splitArgs) < 2 {
-		return m.reply("Sorry, I need to know what you'd like to rename your grocery as. For example: `!grolist:amazon edit-name My Amazon Shopping List` to change a grocery list with the label `amazon` to have the name \"My Amazon Shopping List\". Changing the labels themselves are done through edit-label like so: `!grolist edit-label amazon ebay`.")
+		return m.reply("Sorry, I need to know what you'd like to rename your grocery as. For example: `/grolist:amazon edit-name My Amazon Shopping List` to change a grocery list with the label `amazon` to have the name \"My Amazon Shopping List\". Changing the labels themselves are done through edit-label like so: `/grolist edit-label amazon ebay`.")
 	}
 	newFancyName := splitArgs[1]
 	groceryList, err := m.groceryListRepo.GetByQuery(&models.GroceryList{ListLabel: label})
@@ -226,7 +226,7 @@ func (m *MessageHandlerContext) editList() error {
 		return m.onError(err)
 	}
 	if groceryList == nil {
-		return m.reply(fmt.Sprintf("Whoops, can't seem to find a grocery list with the label **%s**. You can make the grocery list by typing `!grolist new %s %s`.", label, label, newFancyName))
+		return m.reply(fmt.Sprintf("Whoops, can't seem to find a grocery list with the label **%s**. You can make the grocery list by typing `/grolist-new %s %s`.", label, label, newFancyName))
 	}
 	groceryList.FancyName = &newFancyName
 	if err := m.groceryListRepo.Save(groceryList); err != nil {
@@ -245,7 +245,7 @@ func (m *MessageHandlerContext) relabelList() error {
 	}
 	splitArgs := strings.SplitN(m.commandContext.ArgStr, " ", 2)
 	if len(splitArgs) < 2 {
-		return m.reply("Sorry, I need to know what you'd like to relabel your grocery list as. For example: `!grolist:amazon edit-label ebay` to change your `ebay` list's label to `amazon instead` (all items will be moved to the new list).")
+		return m.reply("Sorry, I need to know what you'd like to relabel your grocery list as. For example: `/grolist:amazon edit-label ebay` to change your `ebay` list's label to `amazon instead` (all items will be moved to the new list).")
 	}
 	newLabel := splitArgs[1]
 	groceryList, err := m.groceryListRepo.GetByQuery(&models.GroceryList{ListLabel: label})
@@ -253,14 +253,14 @@ func (m *MessageHandlerContext) relabelList() error {
 		return m.onError(err)
 	}
 	if groceryList == nil {
-		return m.reply(fmt.Sprintf("Whoops, can't seem to find a grocery list with the label **%s**. You can make the grocery list by typing `!grolist new %s My Shopping List`.", label, newLabel))
+		return m.reply(fmt.Sprintf("Whoops, can't seem to find a grocery list with the label **%s**. You can make the grocery list by typing `/grolist-new %s My Shopping List`.", label, newLabel))
 	}
 	groceryList.ListLabel = newLabel
 	if err := m.groceryListRepo.Save(groceryList); err != nil {
 		return m.onError(err)
 	}
 	if err := m.reply(fmt.Sprintf(
-		"Successfully edited grocery list with the label **%s** to have the following label: **%s**. Please ensure that you use commands with the new label! For example: `!gro:%s Chicken strips`",
+		"Successfully edited grocery list with the label **%s** to have the following label: **%s**. Please ensure that you use commands with the new label! For example: `/gro:%s Chicken strips`",
 		label,
 		groceryList.ListLabel,
 		groceryList.ListLabel,

--- a/handlers/gropatron.go
+++ b/handlers/gropatron.go
@@ -18,8 +18,8 @@ func (m *MessageHandlerContext) OnPatron() error {
 	default:
 		return m.reply(`
 Hmm... Not sure what you were looking for. Here are my available commands:
-` + "`!gropatron register`" + ` - registers your account's Patreon benefit for this server.
-` + "`!gropatron deregister`" + ` - deregisters your account's Patreon benefit for this server, and allows you to register other servers (if you've hit your limit).
+` + "`/gropatron register`" + ` - registers your account's Patreon benefit for this server.
+` + "`/gropatron deregister`" + ` - deregisters your account's Patreon benefit for this server, and allows you to register other servers (if you've hit your limit).
 		`)
 	}
 }

--- a/handlers/groreset.go
+++ b/handlers/groreset.go
@@ -21,7 +21,7 @@ func (m *MessageHandlerContext) OnReset() error {
 	if r := m.db.Delete(models.GuildRegistration{}, "guild_id = ?", m.commandContext.GuildID); r.Error != nil {
 		return m.onError(r.Error)
 	}
-	if err := m.reply(":wave: I've successfully deleted all of your data from my database! (p.s. you may need to set up commands such as !grohere again)"); err != nil {
+	if err := m.reply(":wave: I've successfully deleted all of your data from my database! (p.s. you may need to set up commands such as /grohere again)"); err != nil {
 		return m.onError(err)
 	}
 	return nil

--- a/handlers/handler_context.go
+++ b/handlers/handler_context.go
@@ -26,18 +26,19 @@ import (
 const maxCmdCharsProcessedBeforeGivingUp = 48
 
 var (
-	errCannotConvertInt           = errors.New("Oops, I couldn't see any number there... (ps: you can type !grohelp to get help)")
-	errNotValidListNumber         = errors.New("Oops, that doesn't seem like a valid list number! (ps: you can type !grohelp to get help)")
+	errCannotConvertInt           = errors.New("Oops, I couldn't see any number there... (ps: you can type /grohelp to get help)")
+	errNotValidListNumber         = errors.New("Oops, that doesn't seem like a valid list number! (ps: you can type /grohelp to get help)")
 	errPanic                      = errors.New("Hmm... Something broke on my end. Please try again later.")
 	errCmdOverLimit               = errors.New(fmt.Sprintf("Command is too long and exceeds the predefined limit (%d).", maxCmdCharsProcessedBeforeGivingUp))
 	errGroceryListNotFound        = errors.New("Cannot find grocery list from context.")
 	ErrCmdNotProcessable          = errors.New("Command is not a GroceryBot command.")
 	ErrMessageSourceNotRecognised = errors.New("No valid message source is detected. ")
 	msgOverLimit                  = func(limit int) string {
-		return fmt.Sprintf("Whoops, you've gone over the limit allowed by the bot (max %d grocery entries per server). Please log an issue through GitHub (look at `!grohelp`) to request an increase! Thank you for being a power user! :tada:", limit)
+		return fmt.Sprintf("Whoops, you've gone over the limit allowed by the bot (max %d grocery entries per server). Please log an issue through GitHub (look at `/grohelp`) to request an increase! Thank you for being a power user! :tada:", limit)
 	}
 )
 
+// Make sure we keep this using the !gro format.
 const CmdPrefix = "!gro"
 
 // Note: make sure this is alphabetically ordered so that we don't get confused

--- a/handlers/slash/commands.go
+++ b/handlers/slash/commands.go
@@ -30,7 +30,7 @@ type slashCommandHandlerMetadata struct {
 	customArgStrMarshaller argStrMarshaller
 	// determines which option to extract the argStr from
 	mainInputOptionKey string
-	// maybe you want /grolist-new to execute /grolist new instead?
+	// maybe you want /grolist-new to execute !grolist new instead?
 	commandMappingOverride string
 }
 
@@ -226,7 +226,7 @@ var (
 			},
 		},
 		"grolist-new": {
-			commandMappingOverride: "/grolist",
+			commandMappingOverride: "!grolist",
 			customArgStrMarshaller: func(options []*discordgo.ApplicationCommandInteractionDataOption, commandMetadata *slashCommandHandlerMetadata) (argStr string, err error) {
 				label := ""
 				prettyName := ""
@@ -249,7 +249,7 @@ var (
 			},
 		},
 		"grolist-delete": {
-			commandMappingOverride: "/grolist",
+			commandMappingOverride: "!grolist",
 			customArgStrMarshaller: func(options []*discordgo.ApplicationCommandInteractionDataOption, commandMetadata *slashCommandHandlerMetadata) (argStr string, err error) {
 				return "delete", nil
 			},

--- a/handlers/slash/commands.go
+++ b/handlers/slash/commands.go
@@ -30,7 +30,7 @@ type slashCommandHandlerMetadata struct {
 	customArgStrMarshaller argStrMarshaller
 	// determines which option to extract the argStr from
 	mainInputOptionKey string
-	// maybe you want /grolist-new to execute !grolist new instead?
+	// maybe you want /grolist-new to execute /grolist new instead?
 	commandMappingOverride string
 }
 
@@ -226,7 +226,7 @@ var (
 			},
 		},
 		"grolist-new": {
-			commandMappingOverride: "!grolist",
+			commandMappingOverride: "/grolist",
 			customArgStrMarshaller: func(options []*discordgo.ApplicationCommandInteractionDataOption, commandMetadata *slashCommandHandlerMetadata) (argStr string, err error) {
 				label := ""
 				prettyName := ""
@@ -249,7 +249,7 @@ var (
 			},
 		},
 		"grolist-delete": {
-			commandMappingOverride: "!grolist",
+			commandMappingOverride: "/grolist",
 			customArgStrMarshaller: func(options []*discordgo.ApplicationCommandInteractionDataOption, commandMetadata *slashCommandHandlerMetadata) (argStr string, err error) {
 				return "delete", nil
 			},

--- a/handlers/slash/modal.go
+++ b/handlers/slash/modal.go
@@ -78,7 +78,7 @@ var (
 			// }
 			data := &discordgo.InteractionResponseData{
 				CustomID:   "grobulk",
-				Title:      "!grobulk - add multiple groceries",
+				Title:      "/grobulk - add multiple groceries",
 				Components: components,
 			}
 			return data, nil

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -145,7 +145,7 @@ components:
           required: true
         list_label:
           type: string
-          description: The unique label that is used to refer to this grocery list in commands. For example, `!gro:ebay blah` would be referring to a grocery list with `list_label` as "blah".
+          description: The unique label that is used to refer to this grocery list in commands. For example, `/gro:ebay blah` would be referring to a grocery list with `list_label` as "blah".
           required: true
         fancy_name:
           type: string

--- a/services/grocery/update_grohere.go
+++ b/services/grocery/update_grohere.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	ErrCannotUpdateGrohere = errors.New("cannot edit attached message/channel: deleting !grohere entry")
+	ErrCannotUpdateGrohere = errors.New("cannot edit attached message/channel: deleting /grohere entry")
 )
 
 func (s *GroceryServiceImpl) OnGroceryListEdit(ctx context.Context, groceryList *models.GroceryList, guildID string) error {
@@ -45,7 +45,7 @@ func (s *GroceryServiceImpl) OnGroceryListEdit(ctx context.Context, groceryList 
 		s.logger.Error("Detected groceries without matching grocery list IDs.", zap.Any("listlessGroceries", listlessGroceries))
 	}
 	// if (groceryList == nil && count > 0) || (groceryList != nil && count > 1) {
-	// 	grohereText += fmt.Sprintf("\nand %d other grocery lists (use `!grohere all` to get a self-updating list for all groceries, or use `!grolist all` to display them).", count)
+	// 	grohereText += fmt.Sprintf("\nand %d other grocery lists (use `/grohere all` to get a self-updating list for all groceries, or use `/grolist all` to display them).", count)
 	// }
 	// send the message
 	record := grohereRecords[0]
@@ -55,7 +55,7 @@ func (s *GroceryServiceImpl) OnGroceryListEdit(ctx context.Context, groceryList 
 	if err != nil {
 		if discordErr, ok := err.(*discordgo.RESTError); ok {
 			s.logger.Error(
-				"Cannot edit attached message/channel: deleting !grohere entry",
+				"Cannot edit attached message/channel: deleting /grohere entry",
 				zap.Any("DiscordErr", discordErr),
 			)
 			// clear grohere entry as it refers to an unknown channel
@@ -91,7 +91,7 @@ func (s *GroceryServiceImpl) UpdateGuildGrohere(ctx context.Context, guildID str
 	_, err = s.sess.ChannelMessageEdit(*gConfig.GrohereChannelID, *gConfig.GrohereMessageID, grohereText)
 	if err != nil {
 		if discordErr, ok := err.(*discordgo.RESTError); ok {
-			s.logger.Error("Cannot edit attached message/channel: deleting !grohere entry", zap.Any("discordErr", discordErr))
+			s.logger.Error("Cannot edit attached message/channel: deleting /grohere entry", zap.Any("discordErr", discordErr))
 			// clear grohere entry as it refers to an unknown channel
 			gConfig.GrohereChannelID = nil
 			gConfig.GrohereMessageID = nil

--- a/utils/grocery/common.go
+++ b/utils/grocery/common.go
@@ -3,5 +3,5 @@ package groceryutils
 import "fmt"
 
 func getNoGroceryText(label string) string {
-	return fmt.Sprintf("You have no groceries - add one through `!gro` (e.g. `!gro%s Toilet paper`)!\n", label)
+	return fmt.Sprintf("You have no groceries - add one through `/gro` (e.g. `/gro%s Toilet paper`)!\n", label)
 }


### PR DESCRIPTION
There are several places in the bot where the old "message content"-based method of issuing commands to GroceryBot are referenced, including in the bot's name. However, unless you mention the bot directly, these commands will not work, which could lead to some confusing for users. For example, the name of the bot instructs me to type "!grohelp" to get help... but it won't give me any help information unless I @mention it. Changing the in-app hints (along with the documentation) will help with that.

This PR goes through the bot and replaces all of the in-app hints and other documentation (including the bot's home page) with their Slash Command equivalent. I'm marking this as a draft because I don't yet have a great way of explaining the whole "use slash command parameters" concept easily; I'd love your feedback on that!

I'd also like to have the in-app hints use [slash command mentions](https://discord.com/developers/docs/reference#message-formatting) before this comes out of draft.