### PR TITLE
feat: cleanup grocery entries that references a non-existent grocery list

### DIFF
--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -17,3 +17,5 @@ Stack:
 It also has a /docs subfolder which is a web app (Docusaurus) that is independent to the rest of the repo.
 
 You can find the db migrations on `/db/changelog`.
+
+All new repository methods should accept context (even if it's not directly using it) - leave the old repository methods be for backward-compatibility.

--- a/repositories/grocery_entry.go
+++ b/repositories/grocery_entry.go
@@ -35,6 +35,7 @@ type GroceryEntryRepository interface {
 	ClearGroceryList(groceryList *models.GroceryList, guildID string) (rowsAffected int64, err *RepositoryError)
 	Put(g *models.GroceryEntry) error
 	GetCount(query *models.GroceryEntry) (count int64, err error)
+	Delete(ctx context.Context, entry *models.GroceryEntry) error
 }
 
 type GroceryEntryRepositoryImpl struct {
@@ -194,4 +195,12 @@ func (r *GroceryEntryRepositoryImpl) GetCount(query *models.GroceryEntry) (count
 		return 0, r.Error
 	}
 	return count, nil
+}
+
+func (r *GroceryEntryRepositoryImpl) Delete(ctx context.Context, entry *models.GroceryEntry) error {
+	res := r.DB.WithContext(ctx).Delete(entry)
+	if res.Error != nil {
+		return res.Error
+	}
+	return nil
 }

--- a/services/grocery/process_listless_groceries.go
+++ b/services/grocery/process_listless_groceries.go
@@ -1,0 +1,120 @@
+package grocery
+
+import (
+	"context"
+	"time"
+
+	"github.com/verzac/grocer-discord-bot/models"
+	"go.uber.org/zap"
+)
+
+func (s *GroceryServiceImpl) ProcessListlessGroceries(ctx context.Context, groceries []models.GroceryEntry) error {
+	if len(groceries) == 0 {
+		return nil
+	}
+
+	// Queue entries to channel (non-blocking)
+	queuedCount := 0
+	for _, entry := range groceries {
+		select {
+		case s.listlessGroceriesChannel <- entry:
+			queuedCount++
+		default:
+			// Channel is full, log warning and continue
+			s.logger.Warn("ListlessGroceries channel is full, skipping entry",
+				zap.Uint("entryID", entry.ID),
+				zap.String("itemDesc", entry.ItemDesc))
+		}
+	}
+
+	s.logger.Info("Queued listless groceries for processing",
+		zap.Int("queuedCount", queuedCount),
+		zap.Int("totalCount", len(groceries)))
+
+	// Start worker if not already running
+	s.startListlessGroceriesWorker(ctx)
+
+	return nil
+}
+
+func (s *GroceryServiceImpl) startListlessGroceriesWorker(ctx context.Context) {
+	if !s.workerMutex.TryLock() {
+		// Worker is already running, abort immediately
+		return
+	}
+	defer s.workerMutex.Unlock()
+
+	// Check if worker is already running by trying to process from channel
+	select {
+	case entry := <-s.listlessGroceriesChannel:
+		// Got an entry, worker is needed
+		go s.processListlessGroceriesWorker(ctx, entry)
+	default:
+		// No entries in channel, no worker needed
+		return
+	}
+}
+
+func (s *GroceryServiceImpl) processListlessGroceriesWorker(ctx context.Context, firstEntry models.GroceryEntry) {
+	s.logger.Info("Starting listless groceries worker")
+
+	// Process the first entry
+	s.processListlessEntry(ctx, firstEntry)
+
+	// Process remaining entries from channel
+	for {
+		select {
+		case entry := <-s.listlessGroceriesChannel:
+			s.processListlessEntry(ctx, entry)
+		case <-time.After(100 * time.Millisecond):
+			// Channel empty for 100ms, exit worker
+			s.logger.Info("Listless groceries worker exiting - channel empty")
+			return
+		}
+	}
+}
+
+func (s *GroceryServiceImpl) processListlessEntry(ctx context.Context, entry models.GroceryEntry) {
+	// Skip entries with nil GroceryListID (this is valid)
+	if entry.GroceryListID == nil {
+		s.logger.Debug("Skipping entry with nil GroceryListID",
+			zap.Uint("entryID", entry.ID),
+			zap.String("itemDesc", entry.ItemDesc))
+		return
+	}
+
+	// Check if grocery list exists
+	groceryList, err := s.groceryListRepo.GetByQuery(&models.GroceryList{
+		ID: *entry.GroceryListID,
+	})
+	if err != nil {
+		s.logger.Error("Error checking grocery list existence",
+			zap.Uint("entryID", entry.ID),
+			zap.Uint("groceryListID", *entry.GroceryListID),
+			zap.Error(err))
+		return
+	}
+
+	if groceryList == nil {
+		// Grocery list doesn't exist, delete the entry
+		if err := s.groceryEntryRepo.Delete(ctx, &entry); err != nil {
+			s.logger.Error("Failed to delete orphaned grocery entry",
+				zap.Uint("entryID", entry.ID),
+				zap.String("itemDesc", entry.ItemDesc),
+				zap.Uint("groceryListID", *entry.GroceryListID),
+				zap.Error(err))
+		} else {
+			s.logger.Debug("Deleted orphaned grocery entry",
+				zap.Uint("entryID", entry.ID),
+				zap.String("itemDesc", entry.ItemDesc),
+				zap.Uint("groceryListID", *entry.GroceryListID))
+		}
+	} else {
+		// Grocery list exists, this shouldn't happen - log error
+		s.logger.Error("Grocery list exists but entry was marked as listless",
+			zap.Uint("entryID", entry.ID),
+			zap.String("itemDesc", entry.ItemDesc),
+			zap.Uint("groceryListID", *entry.GroceryListID),
+			zap.String("groceryListLabel", groceryList.ListLabel))
+	}
+}

--- a/services/grocery/update_grohere.go
+++ b/services/grocery/update_grohere.go
@@ -42,7 +42,9 @@ func (s *GroceryServiceImpl) OnGroceryListEdit(ctx context.Context, groceryList 
 	}
 	grohereText, listlessGroceries := groceryutils.GetGrohereText(groceryLists, groceries, true)
 	if len(listlessGroceries) > 0 {
-		s.logger.Error("Detected groceries without matching grocery list IDs.", zap.Any("listlessGroceries", listlessGroceries))
+		if err := s.ProcessListlessGroceries(ctx, listlessGroceries); err != nil {
+			s.logger.Error("Failed to process listless groceries", zap.Error(err))
+		}
 	}
 	// if (groceryList == nil && count > 0) || (groceryList != nil && count > 1) {
 	// 	grohereText += fmt.Sprintf("\nand %d other grocery lists (use `!grohere all` to get a self-updating list for all groceries, or use `!grolist all` to display them).", count)
@@ -86,7 +88,9 @@ func (s *GroceryServiceImpl) UpdateGuildGrohere(ctx context.Context, guildID str
 	}
 	grohereText, listlessGroceries := groceryutils.GetGrohereText(groceryLists, groceries, false)
 	if len(listlessGroceries) > 0 {
-		s.logger.Error("listlessGroceries detected.", zap.Any("listlessGroceries", listlessGroceries))
+		if err := s.ProcessListlessGroceries(ctx, listlessGroceries); err != nil {
+			s.logger.Error("Failed to process listless groceries", zap.Error(err))
+		}
 	}
 	_, err = s.sess.ChannelMessageEdit(*gConfig.GrohereChannelID, *gConfig.GrohereMessageID, grohereText)
 	if err != nil {


### PR DESCRIPTION
Not sure how this came about but frankly I don't have the time to do a full-blown investigation. This shouldn't affect normal users - this is just to suppress the no-op errors that are coming in from CloudWatch because I don't think it's worth to resolve.

Note that /grolist-delete should've checked for existing entries before allowing the user to delete the grocery list, so not sure how this came about.

For context, this is what the err log looks like:

<img width="965" height="323" alt="image" src="https://github.com/user-attachments/assets/8bfff959-f59f-4cfa-841e-11f818faf688" />
