### PR TITLE
Feature: add GET /guilds endpoint

### DIFF
--- a/.cursor/specs/SPEC-001-auth-rework-for-apps/progress.md
+++ b/.cursor/specs/SPEC-001-auth-rework-for-apps/progress.md
@@ -1,6 +1,6 @@
 # SPEC-001 Progress Tracker
 
-> Last updated: 2026-04-18
+> Last updated: 2026-04-20
 
 Reference spec: `.cursor/specs/SPEC-001-auth-rework-for-apps/spec.md`
 
@@ -8,7 +8,7 @@ Reference spec: `.cursor/specs/SPEC-001-auth-rework-for-apps/spec.md`
 
 ## Handover Summary (read this first)
 
-**Current state of the codebase:** **Option B (Client-Driven Flow)** is implemented for the OAuth login flow. The Expo app drives OAuth with Discord (`expo-auth-session`); the backend exposes `POST /auth/token` (JSON tokens), `POST /auth/refresh` (includes `expires_in`), and `POST /auth/logout` (Bearer JWT — middleware carve-out so only this `/auth/*` route is authenticated).
+**Current state of the codebase:** **Option B (Client-Driven Flow)** is implemented for the OAuth login flow. The Expo app drives OAuth with Discord (`expo-auth-session`); the backend exposes `POST /auth/token` (JSON tokens), `POST /auth/refresh` (includes `expires_in`), `POST /auth/logout` (Bearer JWT — middleware carve-out so only this `/auth/*` route is authenticated), and **`GET /guilds`** (Bearer JWT; no `X-Guild-ID`; registered with the same OAuth env gate as `/auth/*`).
 
 **Decision made:** Option B (chosen). Option A routes and env vars have been removed.
 
@@ -18,7 +18,7 @@ Reference spec: `.cursor/specs/SPEC-001-auth-rework-for-apps/spec.md`
 
 **Logout (4.5):** Uses **Bearer JWT** only (Approach B). `POST /auth/logout` is excluded from the `/auth/*` auth skip in middleware so the JWT is verified; `X-Guild-ID` is not required (same pattern as `/guilds`). Handler deletes `user_sessions` rows for `sub`.
 
-Also still outstanding: **Area 6** (`GET /guilds`) and **Area 7.2** (user attribution on future edit/delete endpoints).
+**Area 6 (`GET /guilds`):** **Done** (`handlers/api/routeguilds/guilds_handlers.go`). **Area 7.2** (user attribution on future edit endpoints) is not actionable until a grocery edit route exists — see the reminder comment above `POST /groceries` in `handlers/api/routes.go` (`DELETE` does not need `updated_by_id`).
 
 **What to keep unchanged:** JWT issuing/verification (`auth/user_access_jwt.go`), Bearer middleware, `POST /auth/refresh`, encryption (`auth/encryption.go`), refresh token logic, `user_sessions` table + model + repo, `golang.org/x/oauth2` (still used for code exchange in the new endpoint).
 
@@ -153,6 +153,8 @@ Env for `/auth/*`: `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET`, **`SESSION_ENCR
 | 19 | AES-GCM `SESSION_ENCRYPTION_KEY`; Discord tokens encrypted at rest | `auth/encryption.go` | AC-1 |
 | 20 | PKCE client-side (Option B); `auth/pkce.go` utility only | `auth/pkce.go` | — |
 | 21 | `POST /groceries` sets `UpdatedByID` from JWT when Bearer | `handlers/api/routes.go` | AC-6 |
+| 22 | `GET /guilds` — Discord `@me/guilds` + intersect `discordSess.State.Guilds`; refresh via `oauth2.TokenSource`; persist rotated tokens | `handlers/api/routeguilds/guilds_handlers.go` | AC-4 |
+| 23 | Guild list response DTO | `dto/guild.go` | AC-4 |
 
 **Option B refactor (tasks 4.4–4.8):** **Completed.** Old items #13/#14 (`GET /auth/discord`, callback) removed; #11 refactored; server-side PKCE initiation removed from `auth_handlers.go`.
 
@@ -165,7 +167,7 @@ Items are grouped by area and listed in suggested implementation order (dependen
 - [x] **1.1** Add `golang.org/x/oauth2` as a direct dependency in `go.mod`.
 - [x] **1.2** Read `DISCORD_CLIENT_ID`, `DISCORD_CLIENT_SECRET` from env and build an `oauth2.Config` with Discord endpoints. (Option B: `RedirectURL` empty; `DISCORD_REDIRECT_URI` removed.)
 - [x] **1.3** Redirect URI allowlist for token exchange: `ALLOWED_REDIRECT_URIS` (comma-separated; default `grocerybot://auth/callback`). Replaces `APP_REDIRECT_URI` post-callback redirect.
-- [x] **1.4** Graceful degradation: if any Discord OAuth2 env vars are missing, skip registering `/auth/*` routes. The bot must not panic; Basic auth continues to work. (`/guilds` not registered yet — still missing Area 6.) **`SESSION_ENCRYPTION_KEY` is also required for `/auth/*`.**
+- [x] **1.4** Graceful degradation: if any Discord OAuth2 env vars are missing, skip registering `/auth/*` and **`GET /guilds`** routes. The bot must not panic; Basic auth continues to work. **`SESSION_ENCRYPTION_KEY` is also required for `/auth/*` and `/guilds`.**
 
 #### Area 2: Database — `user_sessions` Table (AC-9)
 
@@ -198,14 +200,14 @@ Items are grouped by area and listed in suggested implementation order (dependen
 
 #### Area 6: Guild Listing (AC-4)
 
-- [ ] **6.1** `GET /guilds` handler — load stored Discord access token for the authenticated user, call Discord `GET /users/@me/guilds`, intersect with `discordSess.State.Guilds`, return `[{id, name, icon}]`.
-- [ ] **6.2** If stored Discord token is expired, refresh it using the stored Discord refresh token before retrying.
-- [ ] **6.3** If Discord token cannot be refreshed (revoked), return `401` indicating re-auth is required.
+- [x] **6.1** `GET /guilds` handler — load stored Discord access token for the authenticated user, call Discord `GET /users/@me/guilds`, intersect with `discordSess.State.Guilds`, return `[{id, name, icon}]`. (`handlers/api/routeguilds/guilds_handlers.go`)
+- [x] **6.2** If stored Discord token is expired, refresh it using the stored Discord refresh token before retrying (`oauth2.TokenSource`).
+- [x] **6.3** If Discord token cannot be refreshed (revoked), return `401` indicating re-auth is required.
 
 #### Area 7: User Attribution (AC-6)
 
 - [x] **7.1** In `POST /groceries` handler (`handlers/api/routes.go`), when `authContext.UserID != ""`, set `groceryEntry.UpdatedByID = &authContext.UserID` server-side, overriding any client-supplied value.
-- [ ] **7.2** Apply the same pattern to future edit/delete endpoints.
+- [ ] **7.2** Apply the same pattern to future **edit** endpoints (no edit route in the API yet — see comment above `POST /groceries` in `handlers/api/routes.go`). **`DELETE /groceries` does not set `updated_by_id`.**
 
 ---
 

--- a/dto/guild.go
+++ b/dto/guild.go
@@ -1,0 +1,11 @@
+package dto
+
+type UserGuild struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Icon string `json:"icon"`
+}
+
+type UserGuildsResponse struct {
+	Guilds []UserGuild `json:"guilds"`
+}

--- a/handlers/api/routeguilds/guilds_handlers.go
+++ b/handlers/api/routeguilds/guilds_handlers.go
@@ -1,0 +1,87 @@
+package routeguilds
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/labstack/echo/v4"
+	"github.com/verzac/grocer-discord-bot/dto"
+	apimw "github.com/verzac/grocer-discord-bot/handlers/api/middleware"
+	"github.com/verzac/grocer-discord-bot/services/oauthsession"
+	"go.uber.org/zap"
+)
+
+const discordUsersMeGuildsURL = "https://discord.com/api/users/@me/guilds"
+
+type discordUserGuild struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Icon string `json:"icon"`
+}
+
+// Register mounts GET /guilds (Bearer JWT; no X-Guild-ID). Requires oauthsession.Init before startup.
+func Register(e *echo.Echo, logger *zap.Logger, discordSess *discordgo.Session) {
+	logger = logger.Named("guilds")
+
+	e.GET("/guilds", func(c echo.Context) error {
+		ctx := c.Request().Context()
+		authContext := c.(*apimw.AuthContext)
+		userID := authContext.UserID
+		if userID == "" {
+			return echo.NewHTTPError(http.StatusUnauthorized, "Session not found; please re-authenticate.")
+		}
+
+		client, err := oauthsession.Service.DiscordUserHTTPClient(ctx, userID)
+		if err != nil {
+			return err
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, discordUsersMeGuildsURL, nil)
+		if err != nil {
+			logger.Error("build @me/guilds request", zap.Error(err))
+			return echo.NewHTTPError(http.StatusBadGateway, "Could not reach Discord.")
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			logger.Error("discord @me/guilds request failed", zap.Error(err))
+			return echo.NewHTTPError(http.StatusBadGateway, "Could not reach Discord.")
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return echo.NewHTTPError(http.StatusUnauthorized, "Discord session expired; please re-authenticate.")
+		}
+		if resp.StatusCode != http.StatusOK {
+			logger.Warn("discord @me/guilds non-OK", zap.Int("status", resp.StatusCode))
+			return echo.NewHTTPError(http.StatusBadGateway, "Could not load guilds from Discord.")
+		}
+
+		var userGuilds []discordUserGuild
+		if err := json.NewDecoder(resp.Body).Decode(&userGuilds); err != nil {
+			logger.Error("decode discord guilds", zap.Error(err))
+			return echo.NewHTTPError(http.StatusBadGateway, "Could not load guilds from Discord.")
+		}
+
+		if discordSess == nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, "Cannot resolve bot guilds.")
+		}
+		botGuildIDs := make(map[string]struct{}, len(discordSess.State.Guilds))
+		for _, g := range discordSess.State.Guilds {
+			if g != nil {
+				botGuildIDs[g.ID] = struct{}{}
+			}
+		}
+
+		out := dto.UserGuildsResponse{Guilds: make([]dto.UserGuild, 0, len(userGuilds))}
+		for _, ug := range userGuilds {
+			if _, ok := botGuildIDs[ug.ID]; ok {
+				out.Guilds = append(out.Guilds, dto.UserGuild{
+					ID:   ug.ID,
+					Name: ug.Name,
+					Icon: ug.Icon,
+				})
+			}
+		}
+		return c.JSON(http.StatusOK, out)
+	})
+}

--- a/handlers/api/routes.go
+++ b/handlers/api/routes.go
@@ -16,11 +16,13 @@ import (
 	"github.com/verzac/grocer-discord-bot/handlers"
 	apimw "github.com/verzac/grocer-discord-bot/handlers/api/middleware"
 	"github.com/verzac/grocer-discord-bot/handlers/api/routeauth"
+	"github.com/verzac/grocer-discord-bot/handlers/api/routeguilds"
 	"github.com/verzac/grocer-discord-bot/handlers/api/routetest"
 	"github.com/verzac/grocer-discord-bot/models"
 	"github.com/verzac/grocer-discord-bot/monitoring/groprometheus"
 	"github.com/verzac/grocer-discord-bot/repositories"
 	"github.com/verzac/grocer-discord-bot/services/grocery"
+	"github.com/verzac/grocer-discord-bot/services/oauthsession"
 	"github.com/verzac/grocer-discord-bot/services/registration"
 	"github.com/verzac/grocer-discord-bot/utils"
 	"go.uber.org/zap"
@@ -67,7 +69,9 @@ func RegisterAndStart(logger *zap.Logger, db *gorm.DB, grobotVersion string, dis
 
 	if oauthSetup := auth.LoadOAuthSetup(logger); oauthSetup != nil {
 		auth.InitDefaultJWTIssuer(logger)
+		oauthsession.Init(oauthSetup, userSessionRepo, logger)
 		routeauth.Register(e, logger, oauthSetup, userSessionRepo)
+		routeguilds.Register(e, logger, discordSess)
 	}
 
 	if grobotVersion == config.GrobotVersionLocal {

--- a/services/oauthsession/discord_user_client.go
+++ b/services/oauthsession/discord_user_client.go
@@ -1,0 +1,87 @@
+package oauthsession
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/verzac/grocer-discord-bot/models"
+	"go.uber.org/zap"
+	"golang.org/x/oauth2"
+)
+
+// DiscordUserHTTPClient returns an HTTP client that sends requests with the user's Discord OAuth access token.
+// It refreshes the token via oauth2.TokenSource when needed and best-effort persists rotated tokens to user_sessions.
+func (s *impl) DiscordUserHTTPClient(ctx context.Context, discordUserID string) (*http.Client, error) {
+	sess, err := s.repo.WithContext(ctx).FindByDiscordUserID(ctx, discordUserID)
+	if err != nil {
+		s.log.Error("load user session for discord oauth", zap.Error(err))
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Cannot load session.")
+	}
+	if sess == nil || sess.EncryptedDiscordAccessToken == "" {
+		return nil, ErrSessionNotFound
+	}
+
+	accessPlain, err := s.oauth.TokenEncryptor.Decrypt(sess.EncryptedDiscordAccessToken)
+	if err != nil {
+		s.log.Error("decrypt discord access token", zap.Error(err))
+		return nil, echo.NewHTTPError(http.StatusInternalServerError, "Cannot load session.")
+	}
+	var refreshPlain string
+	if sess.EncryptedDiscordRefreshToken != "" {
+		refreshPlain, err = s.oauth.TokenEncryptor.Decrypt(sess.EncryptedDiscordRefreshToken)
+		if err != nil {
+			s.log.Error("decrypt discord refresh token", zap.Error(err))
+			return nil, echo.NewHTTPError(http.StatusInternalServerError, "Cannot load session.")
+		}
+	}
+
+	stored := &oauth2.Token{
+		AccessToken:  accessPlain,
+		RefreshToken: refreshPlain,
+		Expiry:       sess.DiscordTokenExpiry,
+	}
+	ts := s.oauth.OAuth2.TokenSource(ctx, stored)
+	fresh, err := ts.Token()
+	if err != nil {
+		s.log.Warn("discord token refresh or validate failed", zap.Error(err))
+		return nil, ErrDiscordTokenInvalid
+	}
+
+	s.persistRotatedTokens(ctx, sess, accessPlain, refreshPlain, fresh)
+
+	return s.oauth.OAuth2.Client(ctx, fresh), nil
+}
+
+func (s *impl) persistRotatedTokens(ctx context.Context, sess *models.UserSession, accessPlain, refreshPlain string, fresh *oauth2.Token) {
+	if fresh.AccessToken == accessPlain && fresh.RefreshToken == refreshPlain {
+		return
+	}
+	encAccess, encErr := s.oauth.TokenEncryptor.Encrypt(fresh.AccessToken)
+	if encErr != nil {
+		s.log.Error("encrypt rotated discord access token", zap.Error(encErr))
+		return
+	}
+	sess.EncryptedDiscordAccessToken = encAccess
+	if fresh.RefreshToken != "" {
+		encRef, refErr := s.oauth.TokenEncryptor.Encrypt(fresh.RefreshToken)
+		if refErr != nil {
+			s.log.Error("encrypt rotated discord refresh token", zap.Error(refErr))
+			return
+		}
+		sess.EncryptedDiscordRefreshToken = encRef
+		if !fresh.Expiry.IsZero() {
+			sess.DiscordTokenExpiry = fresh.Expiry
+		}
+		if upErr := s.repo.WithContext(ctx).UpdateSession(ctx, sess); upErr != nil {
+			s.log.Warn("persist rotated discord tokens", zap.Error(upErr))
+		}
+		return
+	}
+	if !fresh.Expiry.IsZero() {
+		sess.DiscordTokenExpiry = fresh.Expiry
+	}
+	if upErr := s.repo.WithContext(ctx).UpdateSession(ctx, sess); upErr != nil {
+		s.log.Warn("persist rotated discord tokens", zap.Error(upErr))
+	}
+}

--- a/services/oauthsession/errors.go
+++ b/services/oauthsession/errors.go
@@ -1,0 +1,14 @@
+package oauthsession
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+var (
+	// ErrSessionNotFound means there is no row or no stored Discord access token for the user.
+	ErrSessionNotFound = echo.NewHTTPError(http.StatusUnauthorized, "Session not found; please re-authenticate.")
+	// ErrDiscordTokenInvalid means the stored Discord token could not be refreshed (e.g. revoked).
+	ErrDiscordTokenInvalid = echo.NewHTTPError(http.StatusUnauthorized, "Discord session expired; please re-authenticate.")
+)

--- a/services/oauthsession/interface.go
+++ b/services/oauthsession/interface.go
@@ -1,0 +1,31 @@
+package oauthsession
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/verzac/grocer-discord-bot/auth"
+	"github.com/verzac/grocer-discord-bot/repositories"
+	"go.uber.org/zap"
+)
+
+var Service OAuthSessionService
+
+type OAuthSessionService interface {
+	DiscordUserHTTPClient(ctx context.Context, discordUserID string) (*http.Client, error)
+}
+
+type impl struct {
+	oauth *auth.OAuthSetup
+	repo  repositories.UserSessionRepository
+	log   *zap.Logger
+}
+
+// Init wires the global Service used by handlers (e.g. GET /guilds). Call when OAuth env is complete.
+func Init(oauthSetup *auth.OAuthSetup, userSessionRepo repositories.UserSessionRepository, logger *zap.Logger) {
+	Service = &impl{
+		oauth: oauthSetup,
+		repo:  userSessionRepo,
+		log:   logger.Named("oauthsession"),
+	}
+}


### PR DESCRIPTION
To be used with user-specific Bearer auth - API keys will not work here.

Motivation: user should be able to select the GroBot server from their list of servers.