### PR TITLE
feat: add new /ingredients command to fetch ingredient list from a YouTube URL

### DIFF
--- a/.cursor/rules/go_code.mdc
+++ b/.cursor/rules/go_code.mdc
@@ -6,3 +6,5 @@ alwaysApply: false
 When creating a function, consider if the function is going to be used in multiple places. If it is only used one-time (excluding tests), make the logic inline, put a comment above the logic, and do NOT create a separate function. Only create functions when you're certain it will be reused elsewhere.
 
 Do not use statement labels (`foo:` before `for`/`switch`/`select`) or `break`/`continue` to a label. Restructure with helpers, flags, or early `continue`/`break` on the innermost loop instead.
+
+For new errors: use `errors.New("literal")` when the message is a fixed string with no formatting. Use `fmt.Errorf("...", args...)` when you need interpolation, and `fmt.Errorf("...: %w", err)` when wrapping another error for `errors.Is` / `errors.As`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@ A Discord bot that maintains grocery lists per-guild, using Go, discordgo, GORM,
 - SQLite DB is embedded — no external database process needed. Migrations run automatically from `db/changelog/` on startup.
 - The REST API starts on `:8080` (in a goroutine) before Discord connects. With an invalid token, the process exits almost immediately after API starts (~250ms window).
 - Environment variables are loaded from `.env` via `godotenv`. See `README.md` for the full list.
+- Optional: set `N8N_API_JWT` and `N8N_WEBHOOK_INGREDIENTS` (webhook URL) together so `/ingredients` can fetch recipes via n8n. The command is always registered; if those are missing, users get a “not configured yet” reply instead.
 - The `db/gorm.db` file is auto-created on first run; the `db/` directory must exist.
 
 ### Docs site (`/docs`)

--- a/README.md
+++ b/README.md
@@ -87,3 +87,5 @@ You may need the following env vars set up:
 
 - GROCER_BOT_TOKEN - your Discord bot token
 - GROCER_BOT_DSN - DSN target, by default it's set to "db/gorm.db"
+- N8N_API_JWT (optional) — with `N8N_WEBHOOK_INGREDIENTS`, turns on recipe fetch for `/ingredients`; sent as the `Authorization` header to that webhook. The `/ingredients` command is always registered; without both vars the bot replies that import is not configured yet.
+- N8N_WEBHOOK_INGREDIENTS (optional) — full URL of the n8n webhook that accepts `{"url":"..."}` and returns ingredient JSON; use together with `N8N_API_JWT` for a working `/ingredients` flow

--- a/config/n8n.go
+++ b/config/n8n.go
@@ -1,0 +1,15 @@
+package config
+
+import "os"
+
+func GetN8NApiJWT() string {
+	return os.Getenv("N8N_API_JWT")
+}
+
+func GetN8NWebhookIngredients() string {
+	return os.Getenv("N8N_WEBHOOK_INGREDIENTS")
+}
+
+func IsN8NEnabled() bool {
+	return GetN8NApiJWT() != "" && GetN8NWebhookIngredients() != ""
+}

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/go-playground/universal-translator v0.18.0 // indirect
 	github.com/google/go-github/v35 v35.2.0 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
+	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -268,6 +268,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
+github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=

--- a/handlers/slash/commands.go
+++ b/handlers/slash/commands.go
@@ -217,6 +217,20 @@ var (
 				},
 			},
 		},
+		{
+			Name:        "ingredients",
+			Description: "Import ingredients from a recipe or video URL into your grocery list.",
+			Type:        discordgo.ChatApplicationCommand,
+			Options: []*discordgo.ApplicationCommandOption{
+				{
+					Type:        discordgo.ApplicationCommandOptionString,
+					Name:        "url",
+					Description: "Recipe page or video URL (e.g. YouTube).",
+					Required:    true,
+				},
+				defaults.DefaultListLabelOption,
+			},
+		},
 	}
 	commandsMetadata = map[string]slashCommandHandlerMetadata{
 		"gro": {

--- a/handlers/slash/native/commons.go
+++ b/handlers/slash/native/commons.go
@@ -2,6 +2,7 @@ package native
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/bwmarrin/discordgo"
 	"github.com/verzac/grocer-discord-bot/models"
@@ -23,6 +24,7 @@ type NativeSlashHandlingContext struct {
 	replyCount            int
 	guildConfigRepository repositories.GuildConfigRepository
 	cachedConfig          *models.GuildConfig
+	customIDSuffix        string
 }
 
 type replyOptions struct {
@@ -85,6 +87,9 @@ var (
 		"developer":               handleDeveloper,
 		"generate_new_api_client": handleDeveloperCreateNewApiClient,
 		"config":                  handleConfig,
+		"ingredients":             handleIngredients,
+		"ingredients_confirm":     handleIngredientsConfirm,
+		"ingredients_cancel":      handleIngredientsCancel,
 	}
 )
 
@@ -97,7 +102,13 @@ type NativeSlashHandlingParams struct {
 }
 
 func Handle(p NativeSlashHandlingParams) bool {
-	handler, ok := nativeSlashHandlerMap[p.CommandName]
+	handlerKey := p.CommandName
+	suffix := ""
+	if parts := strings.SplitN(p.CommandName, ":", 2); len(parts) == 2 {
+		handlerKey = parts[0]
+		suffix = parts[1]
+	}
+	handler, ok := nativeSlashHandlerMap[handlerKey]
 	if !ok {
 		return false
 	}
@@ -107,6 +118,7 @@ func Handle(p NativeSlashHandlingParams) bool {
 		apiClientRepository:   &repositories.ApiClientRepositoryImpl{DB: p.DB},
 		guildConfigRepository: &repositories.GuildConfigRepositoryImpl{DB: p.DB},
 		logger:                p.Logger.Named("native"),
+		customIDSuffix:        suffix,
 	}
 	handler(ctx)
 	return true

--- a/handlers/slash/native/ingredients.go
+++ b/handlers/slash/native/ingredients.go
@@ -1,0 +1,261 @@
+package native
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/bwmarrin/discordgo"
+	"github.com/verzac/grocer-discord-bot/config"
+	"github.com/verzac/grocer-discord-bot/handlers/slash/defaults"
+	"github.com/verzac/grocer-discord-bot/services/ingredients"
+	"github.com/verzac/grocer-discord-bot/utils"
+	"go.uber.org/zap"
+)
+
+const ingredientsMessageMaxRunes = 1800
+
+func handleIngredients(c *NativeSlashHandlingContext) {
+	if c.i.Type != discordgo.InteractionApplicationCommand {
+		return
+	}
+	if !config.IsN8NEnabled() {
+		c.logger.Error("ingredients: disabled because n8n is disabled")
+		if err := c.reply("`/ingredients` isn't ready yet. Please check back in later, or ask the team in the support server when it'll be ready. Thanks!"); err != nil {
+			c.onError(err)
+		}
+		return
+	}
+	url := ""
+	for _, o := range c.i.ApplicationCommandData().Options {
+		if o.Name == "url" {
+			url = strings.TrimSpace(o.StringValue())
+			break
+		}
+	}
+	if url == "" {
+		if err := c.reply("Please provide a **url** to your recipe or video."); err != nil {
+			c.onError(err)
+		}
+		return
+	}
+	listLabel := defaults.ListLabelFromSlashOptions(c.i.ApplicationCommandData().Options)
+
+	if err := c.s.InteractionRespond(c.i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{},
+	}); err != nil {
+		c.logger.Error("ingredients: deferred respond failed", zap.Error(err))
+		return
+	}
+
+	// Discord requires an initial interaction response within ~3s; the deferred ack above satisfies that.
+	// The n8n request and FollowupMessageCreate may take ~10s+. discordgo already runs AddHandler callbacks
+	// on their own goroutine when Session.SyncEvents is false (the default; see Session.handle in event.go),
+	// so this blocking work does not stall the WebSocket read loop—only this handler's goroutine.
+
+	// separate context as it is _technically_ async (the outer context may still have a timeout)
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	items, err := ingredients.Service.FetchIngredients(ctx, url)
+	if err != nil {
+		c.logger.Error("ingredients: fetch error", zap.Error(err))
+		if _, ferr := c.s.FollowupMessageCreate(c.i.Interaction, true, &discordgo.WebhookParams{
+			Content: "Could not fetch ingredients, please try again later. If the problem persists, please contact my hooman. Thanks!",
+		}); ferr != nil {
+			c.logger.Error("ingredients: followup after fetch error", zap.Error(ferr))
+		}
+		return
+	}
+	if len(items) == 0 {
+		if _, ferr := c.s.FollowupMessageCreate(c.i.Interaction, true, &discordgo.WebhookParams{
+			Content: "I didn't get any ingredients back from that link. Try a different URL or add items manually with `/grobulk`.",
+		}); ferr != nil {
+			c.logger.Error("ingredients: followup empty list", zap.Error(ferr))
+		}
+		return
+	}
+	cacheKey := ingredients.Service.StorePending(items, c.i.GuildID, c.i.Member.User.ID, listLabel)
+	body := formatIngredientsFollowupBody(items)
+	_, ferr := c.s.FollowupMessageCreate(c.i.Interaction, true, &discordgo.WebhookParams{
+		Content: body,
+		Components: []discordgo.MessageComponent{
+			discordgo.ActionsRow{
+				Components: []discordgo.MessageComponent{
+					discordgo.Button{
+						Label:    "YES",
+						Style:    discordgo.SuccessButton,
+						CustomID: "ingredients_confirm:" + cacheKey,
+					},
+					discordgo.Button{
+						Label:    "NO",
+						Style:    discordgo.SecondaryButton,
+						CustomID: "ingredients_cancel:" + cacheKey,
+					},
+				},
+			},
+		},
+	})
+	if ferr != nil {
+		c.logger.Error("ingredients: followup with buttons failed", zap.Error(ferr))
+	}
+}
+
+func formatIngredientsFollowupBody(items []string) string {
+	itemsSection := ""
+	isTruncated := false
+	outFmt := `
+Here are the ingredients I found from your recipe:
+
+%s
+
+Does this look right to you?
+`
+	truncatedFromIdx := 0
+	outFmt = strings.TrimSpace(outFmt)
+
+	// calculate the ingredient list section
+	for i, item := range items {
+		line := fmt.Sprintf("%d. %s\n", i+1, item)
+		if len(itemsSection)+len(outFmt)+len(line) > ingredientsMessageMaxRunes {
+			isTruncated = true
+			truncatedFromIdx = i
+			break
+		}
+		itemsSection += line
+	}
+
+	if isTruncated {
+		itemsSection += fmt.Sprintf("\n**and %d other grocery items**\n", len(items)-1-truncatedFromIdx)
+	}
+	out := fmt.Sprintf(outFmt, itemsSection)
+
+	return out
+}
+
+func handleIngredientsConfirm(c *NativeSlashHandlingContext) {
+	if c.i.Type != discordgo.InteractionMessageComponent {
+		return
+	}
+	key := strings.TrimSpace(c.customIDSuffix)
+	if key == "" {
+		if err := respondIngredientsComponentError(c.s, c.i, "Missing confirmation id."); err != nil {
+			c.logger.Error("ingredients_confirm: respond", zap.Error(err))
+		}
+		return
+	}
+	if !ingredientsPendingKeyMatchesGuild(key, c.i.GuildID) {
+		if err := respondIngredientsComponentError(c.s, c.i, "Something went wrong... Please try again."); err != nil {
+			c.logger.Error("ingredients_confirm: guild mismatch", zap.Error(err))
+		}
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	n, err := ingredients.Service.ConfirmAndAdd(ctx, key, c.i.Member.User.ID)
+	if errors.Is(err, ingredients.ErrPendingNotFound) {
+		if err := c.s.InteractionRespond(c.i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseUpdateMessage,
+			Data: &discordgo.InteractionResponseData{
+				Content:    "Sorry, this confirmation has expired. You can copy the ingredients from the list above and add them manually with `/grobulk`.",
+				Components: []discordgo.MessageComponent{},
+			},
+		}); err != nil {
+			c.logger.Error("ingredients_confirm: update expired", zap.Error(err))
+		}
+		return
+	}
+	if errors.Is(err, ingredients.ErrWrongAuthor) {
+		if err := c.s.InteractionRespond(c.i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "Oops, that button can only be pressed by whoever ran `/ingredients`. Please try again.",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		}); err != nil {
+			c.logger.Error("ingredients_confirm: wrong author", zap.Error(err))
+		}
+		return
+	}
+	if err != nil {
+		if err := c.s.InteractionRespond(c.i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: utils.GenericErrorMessage(err),
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		}); err != nil {
+			c.logger.Error("ingredients_confirm: error respond", zap.Error(err))
+		}
+		return
+	}
+	msg := fmt.Sprintf("Added %d items to your grocery list!", n)
+	if err := c.s.InteractionRespond(c.i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{
+			Content:    msg,
+			Components: []discordgo.MessageComponent{},
+		},
+	}); err != nil {
+		c.logger.Error("ingredients_confirm: update success but respond failed", zap.Error(err))
+	}
+}
+
+func handleIngredientsCancel(c *NativeSlashHandlingContext) {
+	if c.i.Type != discordgo.InteractionMessageComponent {
+		return
+	}
+	key := strings.TrimSpace(c.customIDSuffix)
+	if key == "" {
+		if err := respondIngredientsComponentError(c.s, c.i, "Missing confirmation id."); err != nil {
+			c.logger.Error("ingredients_cancel: respond", zap.Error(err))
+		}
+		return
+	}
+	if !ingredientsPendingKeyMatchesGuild(key, c.i.GuildID) {
+		if err := respondIngredientsComponentError(c.s, c.i, "This confirmation doesn't belong to this server."); err != nil {
+			c.logger.Error("ingredients_cancel: guild mismatch", zap.Error(err))
+		}
+		return
+	}
+	authorID, ok := ingredients.Service.PendingAuthorID(key)
+	if ok && authorID != c.i.Member.User.ID {
+		if err := c.s.InteractionRespond(c.i.Interaction, &discordgo.InteractionResponse{
+			Type: discordgo.InteractionResponseChannelMessageWithSource,
+			Data: &discordgo.InteractionResponseData{
+				Content: "Those buttons are for whoever ran `/ingredients`.",
+				Flags:   discordgo.MessageFlagsEphemeral,
+			},
+		}); err != nil {
+			c.logger.Error("ingredients_cancel: wrong author", zap.Error(err))
+		}
+		return
+	}
+	ingredients.Service.Cancel(key)
+	if err := c.s.InteractionRespond(c.i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseUpdateMessage,
+		Data: &discordgo.InteractionResponseData{
+			Content:    "No worries -- ingredients were not added.",
+			Components: []discordgo.MessageComponent{},
+		},
+	}); err != nil {
+		c.logger.Error("ingredients_cancel: update", zap.Error(err))
+	}
+}
+
+func ingredientsPendingKeyMatchesGuild(cacheKey, guildID string) bool {
+	g, _, ok := strings.Cut(cacheKey, ":")
+	return ok && g == guildID
+}
+
+func respondIngredientsComponentError(s *discordgo.Session, i *discordgo.InteractionCreate, msg string) error {
+	return s.InteractionRespond(i.Interaction, &discordgo.InteractionResponse{
+		Type: discordgo.InteractionResponseChannelMessageWithSource,
+		Data: &discordgo.InteractionResponseData{
+			Content: msg,
+			Flags:   discordgo.MessageFlagsEphemeral,
+		},
+	})
+}

--- a/handlers/slash/native/ingredients.go
+++ b/handlers/slash/native/ingredients.go
@@ -45,7 +45,9 @@ func handleIngredients(c *NativeSlashHandlingContext) {
 
 	if err := c.s.InteractionRespond(c.i.Interaction, &discordgo.InteractionResponse{
 		Type: discordgo.InteractionResponseDeferredChannelMessageWithSource,
-		Data: &discordgo.InteractionResponseData{},
+		Data: &discordgo.InteractionResponseData{
+			Content: ":eyes: Fetching ingredients from your link - this may take up to 20 seconds...",
+		},
 	}); err != nil {
 		c.logger.Error("ingredients: deferred respond failed", zap.Error(err))
 		return
@@ -62,8 +64,12 @@ func handleIngredients(c *NativeSlashHandlingContext) {
 	items, err := ingredients.Service.FetchIngredients(ctx, url)
 	if err != nil {
 		c.logger.Error("ingredients: fetch error", zap.Error(err))
+		fetchErrMsg := "Could not fetch ingredients, please try again later. If the problem persists, please contact my hooman. Thanks!"
+		if ingredients.IsErrFetchRecipeNotFound(err) {
+			fetchErrMsg = "I couldn't find a recipe in the given URL. Please try a different URL or add items manually with `/grobulk`."
+		}
 		if _, ferr := c.s.FollowupMessageCreate(c.i.Interaction, true, &discordgo.WebhookParams{
-			Content: "Could not fetch ingredients, please try again later. If the problem persists, please contact my hooman. Thanks!",
+			Content: fetchErrMsg,
 		}); ferr != nil {
 			c.logger.Error("ingredients: followup after fetch error", zap.Error(ferr))
 		}

--- a/repositories/grocery_list.go
+++ b/repositories/grocery_list.go
@@ -1,6 +1,7 @@
 package repositories
 
 import (
+	"context"
 	"errors"
 
 	"github.com/verzac/grocer-discord-bot/models"
@@ -15,6 +16,7 @@ var (
 var _ GroceryListRepository = &GroceryListRepositoryImpl{}
 
 type GroceryListRepository interface {
+	WithContext(ctx context.Context) GroceryListRepository
 	GetByQuery(q *models.GroceryList) (*models.GroceryList, error)
 	FindByQuery(q *models.GroceryList) ([]models.GroceryList, error)
 	Count(q *models.GroceryList) (existingCount int64, err error)
@@ -25,6 +27,10 @@ type GroceryListRepository interface {
 
 type GroceryListRepositoryImpl struct {
 	DB *gorm.DB
+}
+
+func (r *GroceryListRepositoryImpl) WithContext(ctx context.Context) GroceryListRepository {
+	return &GroceryListRepositoryImpl{DB: r.DB.WithContext(ctx)}
 }
 
 func (r *GroceryListRepositoryImpl) GetByQuery(q *models.GroceryList) (*models.GroceryList, error) {

--- a/services/ingredients/cache.go
+++ b/services/ingredients/cache.go
@@ -1,0 +1,62 @@
+package ingredients
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/patrickmn/go-cache"
+)
+
+const pendingDefaultTTL = 5 * time.Minute
+
+type pendingIngredients struct {
+	Ingredients []string
+	GuildID     string
+	AuthorID    string
+	ListLabel   string
+}
+
+type pendingCache struct {
+	c *cache.Cache
+}
+
+func newPendingCache() *pendingCache {
+	return &pendingCache{
+		c: cache.New(pendingDefaultTTL, 10*time.Minute),
+	}
+}
+
+func (p *pendingCache) set(data *pendingIngredients) string {
+	key := data.GuildID + ":" + uuid.NewString()
+	p.c.Set(key, data, pendingDefaultTTL)
+	return key
+}
+
+func (p *pendingCache) peek(key string) (*pendingIngredients, bool) {
+	v, ok := p.c.Get(key)
+	if !ok {
+		return nil, false
+	}
+	out, ok := v.(*pendingIngredients)
+	if !ok {
+		return nil, false
+	}
+	return out, true
+}
+
+func (p *pendingCache) take(key string) (*pendingIngredients, bool) {
+	v, ok := p.c.Get(key)
+	if !ok {
+		return nil, false
+	}
+	p.c.Delete(key)
+	out, ok := v.(*pendingIngredients)
+	if !ok {
+		return nil, false
+	}
+	return out, true
+}
+
+func (p *pendingCache) delete(key string) {
+	p.c.Delete(key)
+}

--- a/services/ingredients/confirm.go
+++ b/services/ingredients/confirm.go
@@ -1,0 +1,112 @@
+package ingredients
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/verzac/grocer-discord-bot/models"
+	"github.com/verzac/grocer-discord-bot/services/grocery"
+	"github.com/verzac/grocer-discord-bot/services/registration"
+	"go.uber.org/zap"
+)
+
+func (s *IngredientsServiceImpl) StorePending(ingredients []string, guildID, authorID, listLabel string) string {
+	return s.memCache.set(&pendingIngredients{
+		Ingredients: ingredients,
+		GuildID:     guildID,
+		AuthorID:    authorID,
+		ListLabel:   strings.TrimSpace(listLabel),
+	})
+}
+
+func (s *IngredientsServiceImpl) Cancel(cacheKey string) {
+	s.memCache.delete(cacheKey)
+}
+
+func (s *IngredientsServiceImpl) PendingAuthorID(cacheKey string) (authorID string, ok bool) {
+	p, ok := s.memCache.peek(cacheKey)
+	if !ok || p == nil {
+		return "", false
+	}
+	return p.AuthorID, true
+}
+
+func (s *IngredientsServiceImpl) ConfirmAndAdd(ctx context.Context, cacheKey, authorID string) (addedCount int, err error) {
+	p0, ok := s.memCache.peek(cacheKey)
+	if !ok {
+		return 0, ErrPendingNotFound
+	}
+	if p0.AuthorID != authorID {
+		return 0, ErrWrongAuthor
+	}
+	keyGuild, _, keyHasGuild := strings.Cut(cacheKey, ":")
+	if !keyHasGuild || keyGuild != p0.GuildID {
+		return 0, ErrPendingNotFound
+	}
+
+	groceryList, err := s.resolveGroceryList(ctx, p0.GuildID, p0.ListLabel)
+	if err != nil {
+		return 0, err
+	}
+
+	toInsert := make([]models.GroceryEntry, 0, len(p0.Ingredients))
+	for _, item := range p0.Ingredients {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		aID := p0.AuthorID
+		toInsert = append(toInsert, models.GroceryEntry{
+			ItemDesc:    item,
+			GuildID:     p0.GuildID,
+			UpdatedByID: &aID,
+		})
+	}
+	if len(toInsert) == 0 {
+		return 0, errors.New("no ingredients to add")
+	}
+
+	registrationContext, regErr := registration.Service.GetRegistrationContext(p0.GuildID)
+	if regErr != nil {
+		s.logger.Error("registration lookup failed", zap.Error(regErr))
+	}
+
+	limitOk, groceryEntryLimit, err := grocery.Service.ValidateGroceryEntryLimit(ctx, registrationContext, p0.GuildID, len(toInsert))
+	if err != nil {
+		return 0, err
+	}
+	if !limitOk {
+		return 0, fmt.Errorf("Whoops, you've gone over the limit allowed by the bot (max %d grocery entries per server). Please log an issue through GitHub (look at `!grohelp`) to request an increase! Thank you for being a power user! :tada:", groceryEntryLimit)
+	}
+
+	pending, ok := s.memCache.take(cacheKey)
+	if !ok {
+		return 0, ErrPendingNotFound
+	}
+
+	rErr := s.groceryEntryRepo.WithContext(ctx).AddToGroceryList(groceryList, toInsert, pending.GuildID)
+	if rErr != nil {
+		return 0, fmt.Errorf("%s", rErr.Message)
+	}
+
+	if err := grocery.Service.OnGroceryListEdit(ctx, groceryList, pending.GuildID); err != nil {
+		return len(toInsert), err
+	}
+	return len(toInsert), nil
+}
+
+func (s *IngredientsServiceImpl) resolveGroceryList(ctx context.Context, guildID, listLabel string) (*models.GroceryList, error) {
+	if listLabel == "" {
+		return nil, nil
+	}
+	gl, err := s.groceryListRepo.WithContext(ctx).GetByQuery(&models.GroceryList{ListLabel: listLabel, GuildID: guildID})
+	if err != nil {
+		return nil, err
+	}
+	if gl == nil {
+		return nil, fmt.Errorf("Whoops, I can't seem to find the grocery list labeled as *%s*.", listLabel)
+	}
+	return gl, nil
+}

--- a/services/ingredients/fetch.go
+++ b/services/ingredients/fetch.go
@@ -50,7 +50,7 @@ func (s *IngredientsServiceImpl) FetchIngredients(ctx context.Context, url strin
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", config.GetN8NApiJWT())
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", config.GetN8NApiJWT()))
 
 	client := &http.Client{Timeout: 30 * time.Second}
 	resp, err := client.Do(req)

--- a/services/ingredients/fetch.go
+++ b/services/ingredients/fetch.go
@@ -23,6 +23,14 @@ type n8nResponse struct {
 	Error string   `json:"error,omitempty"`
 }
 
+func IsErrFetchRecipeNotFound(err error) bool {
+	errMsg := err.Error()
+	if strings.Contains(errMsg, "No recipe URL found in video description.") {
+		return true
+	}
+	return false
+}
+
 func (s *IngredientsServiceImpl) FetchIngredients(ctx context.Context, url string) ([]string, error) {
 	url = strings.TrimSpace(url)
 	if url == "" {
@@ -55,6 +63,13 @@ func (s *IngredientsServiceImpl) FetchIngredients(ctx context.Context, url strin
 		return nil, err
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var errObj struct {
+			Error string `json:"error"`
+		}
+		_ = json.Unmarshal(respBody, &errObj)
+		if errObj.Error != "" {
+			return nil, fmt.Errorf("%s", errObj.Error)
+		}
 		return nil, fmt.Errorf("n8n webhook returned status %d: %s", resp.StatusCode, string(respBody))
 	}
 	var parsed n8nResponse

--- a/services/ingredients/fetch.go
+++ b/services/ingredients/fetch.go
@@ -1,0 +1,75 @@
+package ingredients
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/verzac/grocer-discord-bot/config"
+)
+
+type n8nRequest struct {
+	URL string `json:"url"`
+}
+
+type n8nResponse struct {
+	List  []string `json:"list,omitempty"`
+	Error string   `json:"error,omitempty"`
+}
+
+func (s *IngredientsServiceImpl) FetchIngredients(ctx context.Context, url string) ([]string, error) {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return nil, errors.New("url is required")
+	}
+	webhookURL := strings.TrimSpace(config.GetN8NWebhookIngredients())
+	if webhookURL == "" {
+		return nil, errors.New("N8N_WEBHOOK_INGREDIENTS is not configured")
+	}
+
+	body, err := json.Marshal(n8nRequest{URL: url})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, webhookURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", config.GetN8NApiJWT())
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("n8n webhook returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+	var parsed n8nResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("invalid n8n response: %w", err)
+	}
+	if parsed.Error != "" {
+		return nil, fmt.Errorf("%s", parsed.Error)
+	}
+	out := make([]string, 0, len(parsed.List))
+	for _, line := range parsed.List {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out, nil
+}

--- a/services/ingredients/interface.go
+++ b/services/ingredients/interface.go
@@ -1,0 +1,49 @@
+package ingredients
+
+import (
+	"context"
+	"errors"
+
+	"github.com/verzac/grocer-discord-bot/repositories"
+	"go.uber.org/zap"
+	"gorm.io/gorm"
+)
+
+var (
+	Service IngredientsService
+
+	ErrPendingNotFound = errors.New("pending ingredients not found or expired")
+	ErrWrongAuthor     = errors.New("this confirmation belongs to another user")
+)
+
+type IngredientsService interface {
+	FetchIngredients(ctx context.Context, url string) ([]string, error)
+	StorePending(ingredients []string, guildID, authorID, listLabel string) string
+	PendingAuthorID(cacheKey string) (authorID string, ok bool)
+	ConfirmAndAdd(ctx context.Context, cacheKey, authorID string) (addedCount int, err error)
+	Cancel(cacheKey string)
+}
+
+type IngredientsServiceImpl struct {
+	db               *gorm.DB
+	logger           *zap.Logger
+	memCache         *pendingCache
+	groceryListRepo  repositories.GroceryListRepository
+	groceryEntryRepo repositories.GroceryEntryRepository
+}
+
+func Init(db *gorm.DB, logger *zap.Logger) {
+	if Service == nil {
+		Service = &IngredientsServiceImpl{
+			db:       db,
+			logger:   logger.Named("ingredients"),
+			memCache: newPendingCache(),
+			groceryListRepo: &repositories.GroceryListRepositoryImpl{
+				DB: db,
+			},
+			groceryEntryRepo: &repositories.GroceryEntryRepositoryImpl{
+				DB: db,
+			},
+		}
+	}
+}

--- a/services/init.go
+++ b/services/init.go
@@ -4,6 +4,7 @@ import (
 	"github.com/bwmarrin/discordgo"
 	"github.com/verzac/grocer-discord-bot/services/announcement"
 	"github.com/verzac/grocer-discord-bot/services/grocery"
+	"github.com/verzac/grocer-discord-bot/services/ingredients"
 	"github.com/verzac/grocer-discord-bot/services/guildconfig"
 	"github.com/verzac/grocer-discord-bot/services/guilds"
 	"github.com/verzac/grocer-discord-bot/services/registration"
@@ -14,6 +15,7 @@ import (
 func InitServices(db *gorm.DB, logger *zap.Logger, sess *discordgo.Session) {
 	registration.Init(db, logger)
 	grocery.Init(db, logger, sess)
+	ingredients.Init(db, logger)
 	guildconfig.Init(db, logger)
 	announcement.Init(db, logger)
 	guilds.Init(db)


### PR DESCRIPTION
Functionality:
1. `/ingredients url:https://www.youtube.com/watch?v=-n-AFeSLUfc` attempts to retrieve the Bluey Duck Cake recipe from the video description
2. If the video description does not contain a recipe (determined by LLM), then it attempts to find a recipe URL
3. If a recipe URL is found, then fetch that URL and _try_ to get an ingredient list from the site itself (using LLM)

Note that this functionality is planned to be exclusive to Patreon members.

<img width="400" height="632" alt="image" src="https://github.com/user-attachments/assets/13af033e-11a5-4d01-b955-e60a877a5c8a" />


---

Changes:
- added support for adding extra data to native slash command handlers through its `custom_id` (used for passing in the cache key for ingredients' pending ingredients list)
- added IngredientsService and /ingredients
- added N8N_API_JWT, which is generated by Ben's n8n instance
- added N8N_WEBHOOK_INGREDIENTS

We're putting the bulk logic in N8N first because it's easier to prototype/debug (plus easier to setup since I already have my OpenAI creds there). We'll probably port it to Go if demand is there.