### PR TITLE
feat(api): implement POST, DELETE, PATCH /grocery-lists

### DIFF
--- a/dto/grocery_list_requests.go
+++ b/dto/grocery_list_requests.go
@@ -1,0 +1,10 @@
+package dto
+
+type CreateGroceryListRequest struct {
+	ListLabel string  `json:"list_label" validate:"required"`
+	FancyName *string `json:"fancy_name"`
+}
+
+type UpdateGroceryListRequest struct {
+	FancyName *string `json:"fancy_name" validate:"required"`
+}

--- a/dto/grocery_list_requests.go
+++ b/dto/grocery_list_requests.go
@@ -4,7 +4,3 @@ type CreateGroceryListRequest struct {
 	ListLabel string  `json:"list_label" validate:"required"`
 	FancyName *string `json:"fancy_name"`
 }
-
-type UpdateGroceryListRequest struct {
-	FancyName *string `json:"fancy_name" validate:"required"`
-}

--- a/dto/registration_context.go
+++ b/dto/registration_context.go
@@ -1,6 +1,7 @@
 package dto
 
 type RegistrationContext struct {
+	// MaxGroceryListsPerServer includes the implicit default list. Stored GroceryList rows only count named lists.
 	MaxGroceryListsPerServer   int
 	MaxGroceryEntriesPerServer int
 	IsDefault                  bool

--- a/e2e/api/apiharness/setup.go
+++ b/e2e/api/apiharness/setup.go
@@ -174,9 +174,6 @@ func (s *APITestSession) CleanupAllGroceryLists() error {
 			return err
 		}
 		_, _ = ReadBodyAndClose(res)
-		if res.StatusCode == http.StatusNotImplemented {
-			continue
-		}
 		if res.StatusCode != http.StatusNoContent {
 			return fmt.Errorf("delete grocery list %d: unexpected status %d", gl.ID, res.StatusCode)
 		}
@@ -220,4 +217,3 @@ func (s *APITestSession) CleanupAllGroceries() error {
 	}
 	return nil
 }
-

--- a/e2e/api/apiharness/setup.go
+++ b/e2e/api/apiharness/setup.go
@@ -129,6 +129,61 @@ func (s *APITestSession) FetchGroceryLists() (*dto.GuildGroceryList, int, error)
 	return &out, res.StatusCode, nil
 }
 
+func (s *APITestSession) PostGroceryList(body []byte) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPost, s.baseURL+"/grocery-lists", bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	s.applyAuth(req)
+	return s.client.Do(req)
+}
+
+func (s *APITestSession) DeleteGroceryList(id uint) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodDelete,
+		fmt.Sprintf("%s/grocery-lists/%d", s.baseURL, id), nil)
+	if err != nil {
+		return nil, err
+	}
+	s.applyAuth(req)
+	return s.client.Do(req)
+}
+
+func (s *APITestSession) PatchGroceryList(id uint, body []byte) (*http.Response, error) {
+	req, err := http.NewRequest(http.MethodPatch,
+		fmt.Sprintf("%s/grocery-lists/%d", s.baseURL, id), bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	s.applyAuth(req)
+	return s.client.Do(req)
+}
+
+func (s *APITestSession) CleanupAllGroceryLists() error {
+	lists, status, err := s.FetchGroceryLists()
+	if err != nil {
+		return err
+	}
+	if status != http.StatusOK {
+		return fmt.Errorf("cleanup: GET /grocery-lists returned %d", status)
+	}
+	for _, gl := range lists.GroceryLists {
+		res, err := s.DeleteGroceryList(gl.ID)
+		if err != nil {
+			return err
+		}
+		_, _ = ReadBodyAndClose(res)
+		if res.StatusCode == http.StatusNotImplemented {
+			continue
+		}
+		if res.StatusCode != http.StatusNoContent {
+			return fmt.Errorf("delete grocery list %d: unexpected status %d", gl.ID, res.StatusCode)
+		}
+	}
+	return nil
+}
+
 func (s *APITestSession) CleanupAllGroceries() error {
 	lists, status, err := s.FetchGroceryLists()
 	if err != nil {

--- a/e2e/api/e2e_api_test.go
+++ b/e2e/api/e2e_api_test.go
@@ -241,6 +241,194 @@ func TestCRDFlow(t *testing.T) {
 	require.Empty(t, lists.GroceryEntries)
 }
 
+func cleanupGroceryLists(t *testing.T) {
+	t.Helper()
+	require.NoError(t, apiSess.CleanupAllGroceryLists())
+}
+
+func postGroceryList(t *testing.T, body string) models.GroceryList {
+	t.Helper()
+	res, err := apiSess.PostGroceryList([]byte(body))
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, res.StatusCode, "%s", string(b))
+	var out models.GroceryList
+	require.NoError(t, json.Unmarshal(b, &out))
+	return out
+}
+
+func TestCreateGroceryList(t *testing.T) {
+	cleanupGroceryLists(t)
+	defer cleanupGroceryLists(t)
+
+	gl := postGroceryList(t, `{"list_label":"fruit"}`)
+	require.NotZero(t, gl.ID)
+	require.Equal(t, "fruit", gl.ListLabel)
+}
+
+func TestCreateGroceryListReadBack(t *testing.T) {
+	cleanupGroceryLists(t)
+	defer cleanupGroceryLists(t)
+
+	postGroceryList(t, `{"list_label":"veggies"}`)
+
+	lists, status, err := apiSess.FetchGroceryLists()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	found := false
+	for _, gl := range lists.GroceryLists {
+		if gl.ListLabel == "veggies" {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "expected grocery list in grocery_lists")
+}
+
+func TestCreateGroceryListDuplicate(t *testing.T) {
+	cleanupGroceryLists(t)
+	defer cleanupGroceryLists(t)
+
+	postGroceryList(t, `{"list_label":"fruit"}`)
+
+	res, err := apiSess.PostGroceryList([]byte(`{"list_label":"fruit"}`))
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode, "%s", string(b))
+}
+
+func TestCreateGroceryListInvalidLabel(t *testing.T) {
+	cleanupGroceryLists(t)
+	defer cleanupGroceryLists(t)
+
+	res, err := apiSess.PostGroceryList([]byte(`{"list_label":"fruit123"}`))
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode, "%s", string(b))
+}
+
+func TestCreateGroceryListLimitReached(t *testing.T) {
+	cleanupGroceryLists(t)
+	defer cleanupGroceryLists(t)
+
+	// default limit is 3, but the >= condition means only 2 can be created
+	postGroceryList(t, `{"list_label":"listA"}`)
+	postGroceryList(t, `{"list_label":"listB"}`)
+
+	res, err := apiSess.PostGroceryList([]byte(`{"list_label":"listC"}`))
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode, "%s", string(b))
+}
+
+func TestCreateGroceryListMissingLabel(t *testing.T) {
+	res, err := apiSess.PostGroceryList([]byte(`{}`))
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode, "%s", string(b))
+}
+
+func TestDeleteGroceryList(t *testing.T) {
+	cleanupGroceryLists(t)
+	defer cleanupGroceryLists(t)
+
+	gl := postGroceryList(t, `{"list_label":"todelete"}`)
+
+	res, err := apiSess.DeleteGroceryList(gl.ID)
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, res.StatusCode, "%s", string(b))
+
+	lists, status, err := apiSess.FetchGroceryLists()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	for _, l := range lists.GroceryLists {
+		require.NotEqual(t, gl.ID, l.ID, "list should be deleted")
+	}
+}
+
+func TestDeleteGroceryListNotFound(t *testing.T) {
+	res, err := apiSess.DeleteGroceryList(999999999)
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, res.StatusCode, "%s", string(b))
+}
+
+func TestPatchGroceryList(t *testing.T) {
+	cleanupGroceryLists(t)
+	defer cleanupGroceryLists(t)
+
+	gl := postGroceryList(t, `{"list_label":"patchme"}`)
+
+	res, err := apiSess.PatchGroceryList(gl.ID, []byte(`{"fancy_name":"My Patched List"}`))
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode, "%s", string(b))
+
+	var updated models.GroceryList
+	require.NoError(t, json.Unmarshal(b, &updated))
+	require.NotNil(t, updated.FancyName)
+	require.Equal(t, "My Patched List", *updated.FancyName)
+}
+
+func TestPatchGroceryListNotFound(t *testing.T) {
+	res, err := apiSess.PatchGroceryList(999999999, []byte(`{"fancy_name":"Ghost"}`))
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, res.StatusCode, "%s", string(b))
+}
+
+func TestPatchGroceryListMissingFancyName(t *testing.T) {
+	cleanupGroceryLists(t)
+	defer cleanupGroceryLists(t)
+
+	gl := postGroceryList(t, `{"list_label":"patchvalidate"}`)
+
+	res, err := apiSess.PatchGroceryList(gl.ID, []byte(`{}`))
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode, "%s", string(b))
+}
+
+func TestDeleteGroceryListWithEntries(t *testing.T) {
+	cleanupGroceries(t)
+	cleanupGroceryLists(t)
+	defer func() {
+		cleanupGroceries(t)
+		cleanupGroceryLists(t)
+	}()
+
+	gl := postGroceryList(t, `{"list_label":"nonempty"}`)
+
+	glID := gl.ID
+	body, err := json.Marshal(map[string]interface{}{
+		"item_desc":       "some item",
+		"grocery_list_id": glID,
+	})
+	require.NoError(t, err)
+	res, err := apiSess.PostJSON("/groceries", body)
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusCreated, res.StatusCode, "%s", string(b))
+
+	res, err = apiSess.DeleteGroceryList(gl.ID)
+	require.NoError(t, err)
+	b, err = apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusConflict, res.StatusCode, "%s", string(b))
+}
+
 func uintToStr(id uint) string {
 	return strconv.FormatUint(uint64(id), 10)
 }

--- a/e2e/api/e2e_api_test.go
+++ b/e2e/api/e2e_api_test.go
@@ -314,11 +314,11 @@ func TestCreateGroceryListLimitReached(t *testing.T) {
 	cleanupGroceryLists(t)
 	defer cleanupGroceryLists(t)
 
+	// Match handlers/grolist.go: the existing command path is the source of truth.
 	postGroceryList(t, `{"list_label":"listA"}`)
 	postGroceryList(t, `{"list_label":"listB"}`)
-	postGroceryList(t, `{"list_label":"listC"}`)
 
-	res, err := apiSess.PostGroceryList([]byte(`{"list_label":"listD"}`))
+	res, err := apiSess.PostGroceryList([]byte(`{"list_label":"listC"}`))
 	require.NoError(t, err)
 	b, err := apiharness.ReadBodyAndClose(res)
 	require.NoError(t, err)

--- a/e2e/api/e2e_api_test.go
+++ b/e2e/api/e2e_api_test.go
@@ -314,11 +314,11 @@ func TestCreateGroceryListLimitReached(t *testing.T) {
 	cleanupGroceryLists(t)
 	defer cleanupGroceryLists(t)
 
-	// default limit is 3, but the >= condition means only 2 can be created
 	postGroceryList(t, `{"list_label":"listA"}`)
 	postGroceryList(t, `{"list_label":"listB"}`)
+	postGroceryList(t, `{"list_label":"listC"}`)
 
-	res, err := apiSess.PostGroceryList([]byte(`{"list_label":"listC"}`))
+	res, err := apiSess.PostGroceryList([]byte(`{"list_label":"listD"}`))
 	require.NoError(t, err)
 	b, err := apiharness.ReadBodyAndClose(res)
 	require.NoError(t, err)
@@ -361,6 +361,31 @@ func TestDeleteGroceryListNotFound(t *testing.T) {
 	require.Equal(t, http.StatusNotFound, res.StatusCode, "%s", string(b))
 }
 
+func TestDeleteGroceryListZeroID(t *testing.T) {
+	cleanupGroceryLists(t)
+	defer cleanupGroceryLists(t)
+
+	gl := postGroceryList(t, `{"list_label":"zerodelete"}`)
+
+	res, err := apiSess.DeleteGroceryList(0)
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode, "%s", string(b))
+
+	lists, status, err := apiSess.FetchGroceryLists()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	found := false
+	for _, l := range lists.GroceryLists {
+		if l.ID == gl.ID {
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "zero ID delete must not delete an existing list")
+}
+
 func TestPatchGroceryList(t *testing.T) {
 	cleanupGroceryLists(t)
 	defer cleanupGroceryLists(t)
@@ -379,12 +404,53 @@ func TestPatchGroceryList(t *testing.T) {
 	require.Equal(t, "My Patched List", *updated.FancyName)
 }
 
+func TestPatchGroceryListClearFancyName(t *testing.T) {
+	cleanupGroceryLists(t)
+	defer cleanupGroceryLists(t)
+
+	gl := postGroceryList(t, `{"list_label":"clearname","fancy_name":"Clear Me"}`)
+
+	res, err := apiSess.PatchGroceryList(gl.ID, []byte(`{"fancy_name":null}`))
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, res.StatusCode, "%s", string(b))
+
+	var updated models.GroceryList
+	require.NoError(t, json.Unmarshal(b, &updated))
+	require.Nil(t, updated.FancyName)
+}
+
 func TestPatchGroceryListNotFound(t *testing.T) {
 	res, err := apiSess.PatchGroceryList(999999999, []byte(`{"fancy_name":"Ghost"}`))
 	require.NoError(t, err)
 	b, err := apiharness.ReadBodyAndClose(res)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNotFound, res.StatusCode, "%s", string(b))
+}
+
+func TestPatchGroceryListZeroID(t *testing.T) {
+	cleanupGroceryLists(t)
+	defer cleanupGroceryLists(t)
+
+	gl := postGroceryList(t, `{"list_label":"zeropatch"}`)
+
+	res, err := apiSess.PatchGroceryList(0, []byte(`{"fancy_name":"Should Not Patch"}`))
+	require.NoError(t, err)
+	b, err := apiharness.ReadBodyAndClose(res)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusBadRequest, res.StatusCode, "%s", string(b))
+
+	lists, status, err := apiSess.FetchGroceryLists()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, status)
+	for _, l := range lists.GroceryLists {
+		if l.ID == gl.ID {
+			require.Nil(t, l.FancyName)
+			return
+		}
+	}
+	require.Fail(t, "expected list to remain after zero ID patch")
 }
 
 func TestPatchGroceryListMissingFancyName(t *testing.T) {

--- a/handlers/api/routegrocerylists/grocery_lists_handlers.go
+++ b/handlers/api/routegrocerylists/grocery_lists_handlers.go
@@ -1,9 +1,11 @@
 package routegrocerylists
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 
+	"github.com/bwmarrin/discordgo"
 	"github.com/labstack/echo/v4"
 	"github.com/verzac/grocer-discord-bot/dto"
 	"github.com/verzac/grocer-discord-bot/handlers"
@@ -24,6 +26,7 @@ func Register(
 	groceryListRepo repositories.GroceryListRepository,
 	groceryEntryRepo repositories.GroceryEntryRepository,
 	grohereRecordRepo repositories.GrohereRecordRepository,
+	discordSess *discordgo.Session,
 ) {
 	logger = logger.Named("grocery-lists")
 
@@ -48,11 +51,12 @@ func Register(
 		if err != nil {
 			return err
 		}
-		existingCount, err := groceryListRepo.WithContext(c.Request().Context()).Count(&models.GroceryList{GuildID: guildID})
+		ctx := c.Request().Context()
+		existingCount, err := groceryListRepo.WithContext(ctx).Count(&models.GroceryList{GuildID: guildID})
 		if err != nil {
 			return err
 		}
-		if existingCount+1 >= int64(registrationContext.MaxGroceryListsPerServer) {
+		if existingCount >= int64(registrationContext.MaxGroceryListsPerServer) {
 			return echo.NewHTTPError(400, fmt.Sprintf(
 				"You've reached the max number of grocery lists for this server (%d).",
 				registrationContext.MaxGroceryListsPerServer,
@@ -64,12 +68,15 @@ func Register(
 			fancyName = *req.FancyName
 		}
 
-		newList, err := groceryListRepo.WithContext(c.Request().Context()).CreateGroceryList(guildID, req.ListLabel, fancyName)
+		newList, err := groceryListRepo.WithContext(ctx).CreateGroceryList(guildID, req.ListLabel, fancyName)
 		if err != nil {
 			if err == repositories.ErrGroceryListDuplicate {
 				return echo.NewHTTPError(400, err.Error())
 			}
 			return err
+		}
+		if err := grocery.Service.UpdateGuildGrohere(ctx, guildID); err != nil {
+			logger.Error("Failed to update grohere after grocery list creation", zap.Error(err))
 		}
 		return c.JSON(201, newList)
 	})
@@ -80,7 +87,7 @@ func Register(
 
 		idStr := c.Param("id")
 		id, err := strconv.ParseUint(idStr, 10, 64)
-		if err != nil {
+		if err != nil || id == 0 {
 			return echo.NewHTTPError(400, "Invalid ID format.")
 		}
 
@@ -104,12 +111,26 @@ func Register(
 			return echo.NewHTTPError(409, fmt.Sprintf("Cannot delete: grocery list still has %d entries.", count))
 		}
 
-		grohereRecords, err := grohereRecordRepo.FindByQuery(&models.GrohereRecord{GroceryListID: &groceryList.ID})
+		grohereRecords, err := grohereRecordRepo.FindByQuery(&models.GrohereRecord{
+			GuildID:       guildID,
+			GroceryListID: &groceryList.ID,
+		})
 		if err != nil {
 			return err
 		}
 		for i := range grohereRecords {
-			if err := grohereRecordRepo.Delete(&grohereRecords[i]); err != nil {
+			record := &grohereRecords[i]
+			if discordSess != nil {
+				_, err := discordSess.ChannelMessageEdit(
+					record.GrohereChannelID,
+					record.GrohereMessageID,
+					fmt.Sprintf(":shopping_cart: %s\n *:wave: This grocery list has been deleted. Type `!grohere:<your-new-grocery-list>` to get a self-updating message for your grocery list!*", groceryList.GetName()),
+				)
+				if err != nil {
+					logger.Error("Failed to edit grohere message after grocery list deletion", zap.Error(err))
+				}
+			}
+			if err := grohereRecordRepo.Delete(record); err != nil {
 				return err
 			}
 		}
@@ -134,16 +155,21 @@ func Register(
 
 		idStr := c.Param("id")
 		id, err := strconv.ParseUint(idStr, 10, 64)
-		if err != nil {
+		if err != nil || id == 0 {
 			return echo.NewHTTPError(400, "Invalid ID format.")
 		}
 
-		req := dto.UpdateGroceryListRequest{}
-		if err := c.Bind(&req); err != nil {
+		req := map[string]json.RawMessage{}
+		if err := json.NewDecoder(c.Request().Body).Decode(&req); err != nil {
 			return echo.NewHTTPError(400, "Invalid request body.")
 		}
-		if err := c.Validate(&req); err != nil {
-			return echo.NewHTTPError(400, err.Error())
+		rawFancyName, ok := req["fancy_name"]
+		if !ok {
+			return echo.NewHTTPError(400, "fancy_name is required.")
+		}
+		var fancyName *string
+		if err := json.Unmarshal(rawFancyName, &fancyName); err != nil {
+			return echo.NewHTTPError(400, "Invalid request body.")
 		}
 
 		ctx := c.Request().Context()
@@ -158,7 +184,7 @@ func Register(
 			return echo.NewHTTPError(404, repositories.ErrGroceryListNotFound.Error())
 		}
 
-		groceryList.FancyName = req.FancyName
+		groceryList.FancyName = fancyName
 		if err := groceryListRepo.WithContext(ctx).Save(groceryList); err != nil {
 			return err
 		}

--- a/handlers/api/routegrocerylists/grocery_lists_handlers.go
+++ b/handlers/api/routegrocerylists/grocery_lists_handlers.go
@@ -19,7 +19,6 @@ import (
 )
 
 // Register mounts /grocery-lists mutation routes (POST, DELETE /:id, PATCH /:id).
-// Not yet implemented — see handlers/grolist.go (newList, deleteList, editList).
 func Register(
 	e *echo.Echo,
 	logger *zap.Logger,

--- a/handlers/api/routegrocerylists/grocery_lists_handlers.go
+++ b/handlers/api/routegrocerylists/grocery_lists_handlers.go
@@ -51,14 +51,14 @@ func Register(
 			return err
 		}
 		ctx := c.Request().Context()
-		existingCount, err := groceryListRepo.WithContext(ctx).Count(&models.GroceryList{GuildID: guildID})
+		limitOk, groceryListLimit, err := grocery.Service.ValidateGroceryListLimit(ctx, registrationContext, guildID)
 		if err != nil {
 			return err
 		}
-		if existingCount+1 >= int64(registrationContext.MaxGroceryListsPerServer) {
+		if !limitOk {
 			return echo.NewHTTPError(400, fmt.Sprintf(
 				"You've reached the max number of grocery lists for this server (%d).",
-				registrationContext.MaxGroceryListsPerServer,
+				groceryListLimit,
 			))
 		}
 

--- a/handlers/api/routegrocerylists/grocery_lists_handlers.go
+++ b/handlers/api/routegrocerylists/grocery_lists_handlers.go
@@ -1,13 +1,18 @@
 package routegrocerylists
 
 import (
+	"fmt"
 	"strconv"
 
 	"github.com/labstack/echo/v4"
 	"github.com/verzac/grocer-discord-bot/dto"
 	"github.com/verzac/grocer-discord-bot/handlers"
 	apimw "github.com/verzac/grocer-discord-bot/handlers/api/middleware"
+	"github.com/verzac/grocer-discord-bot/models"
 	"github.com/verzac/grocer-discord-bot/repositories"
+	"github.com/verzac/grocer-discord-bot/services/grocery"
+	"github.com/verzac/grocer-discord-bot/services/registration"
+	"github.com/verzac/grocer-discord-bot/utils"
 	"go.uber.org/zap"
 )
 
@@ -18,13 +23,14 @@ func Register(
 	logger *zap.Logger,
 	groceryListRepo repositories.GroceryListRepository,
 	groceryEntryRepo repositories.GroceryEntryRepository,
+	grohereRecordRepo repositories.GrohereRecordRepository,
 ) {
 	logger = logger.Named("grocery-lists")
 
 	e.POST("/grocery-lists", func(c echo.Context) error {
 		defer handlers.Recover(logger)
 		authContext := c.(*apimw.AuthContext)
-		_ = authContext.GuildID
+		guildID := authContext.GuildID
 
 		req := dto.CreateGroceryListRequest{}
 		if err := c.Bind(&req); err != nil {
@@ -34,27 +40,101 @@ func Register(
 			return echo.NewHTTPError(400, err.Error())
 		}
 
-		return echo.NewHTTPError(501, "Not implemented.")
+		if err := utils.ValidateSublistLabel(req.ListLabel); err != nil {
+			return echo.NewHTTPError(400, err.Error())
+		}
+
+		registrationContext, err := registration.Service.GetRegistrationContext(guildID)
+		if err != nil {
+			return err
+		}
+		existingCount, err := groceryListRepo.WithContext(c.Request().Context()).Count(&models.GroceryList{GuildID: guildID})
+		if err != nil {
+			return err
+		}
+		if existingCount+1 >= int64(registrationContext.MaxGroceryListsPerServer) {
+			return echo.NewHTTPError(400, fmt.Sprintf(
+				"You've reached the max number of grocery lists for this server (%d).",
+				registrationContext.MaxGroceryListsPerServer,
+			))
+		}
+
+		var fancyName string
+		if req.FancyName != nil {
+			fancyName = *req.FancyName
+		}
+
+		newList, err := groceryListRepo.WithContext(c.Request().Context()).CreateGroceryList(guildID, req.ListLabel, fancyName)
+		if err != nil {
+			if err == repositories.ErrGroceryListDuplicate {
+				return echo.NewHTTPError(400, err.Error())
+			}
+			return err
+		}
+		return c.JSON(201, newList)
 	})
 	e.DELETE("/grocery-lists/:id", func(c echo.Context) error {
 		defer handlers.Recover(logger)
 		authContext := c.(*apimw.AuthContext)
-		_ = authContext.GuildID
+		guildID := authContext.GuildID
 
 		idStr := c.Param("id")
-		if _, err := strconv.ParseUint(idStr, 10, 64); err != nil {
+		id, err := strconv.ParseUint(idStr, 10, 64)
+		if err != nil {
 			return echo.NewHTTPError(400, "Invalid ID format.")
 		}
 
-		return echo.NewHTTPError(501, "Not implemented.")
+		ctx := c.Request().Context()
+		groceryList, err := groceryListRepo.WithContext(ctx).GetByQuery(&models.GroceryList{
+			ID:      uint(id),
+			GuildID: guildID,
+		})
+		if err != nil {
+			return err
+		}
+		if groceryList == nil {
+			return echo.NewHTTPError(404, repositories.ErrGroceryListNotFound.Error())
+		}
+
+		count, err := groceryEntryRepo.GetCount(&models.GroceryEntry{GuildID: guildID, GroceryListID: &groceryList.ID})
+		if err != nil {
+			return err
+		}
+		if count > 0 {
+			return echo.NewHTTPError(409, fmt.Sprintf("Cannot delete: grocery list still has %d entries.", count))
+		}
+
+		grohereRecords, err := grohereRecordRepo.FindByQuery(&models.GrohereRecord{GroceryListID: &groceryList.ID})
+		if err != nil {
+			return err
+		}
+		for i := range grohereRecords {
+			if err := grohereRecordRepo.Delete(&grohereRecords[i]); err != nil {
+				return err
+			}
+		}
+
+		if err := groceryListRepo.WithContext(ctx).Delete(groceryList); err != nil {
+			if err == repositories.ErrGroceryListNotFound {
+				return echo.NewHTTPError(404, err.Error())
+			}
+			return err
+		}
+
+		if err := grocery.Service.UpdateGuildGrohere(ctx, guildID); err != nil {
+			logger.Error("Failed to update grohere after grocery list deletion", zap.Error(err))
+		}
+
+		return c.NoContent(204)
 	})
 	e.PATCH("/grocery-lists/:id", func(c echo.Context) error {
 		defer handlers.Recover(logger)
 		authContext := c.(*apimw.AuthContext)
-		_ = authContext.GuildID
+		guildID := authContext.GuildID
 
 		idStr := c.Param("id")
-		if _, err := strconv.ParseUint(idStr, 10, 64); err != nil {
+		id, err := strconv.ParseUint(idStr, 10, 64)
+		if err != nil {
 			return echo.NewHTTPError(400, "Invalid ID format.")
 		}
 
@@ -66,6 +146,27 @@ func Register(
 			return echo.NewHTTPError(400, err.Error())
 		}
 
-		return echo.NewHTTPError(501, "Not implemented.")
+		ctx := c.Request().Context()
+		groceryList, err := groceryListRepo.WithContext(ctx).GetByQuery(&models.GroceryList{
+			ID:      uint(id),
+			GuildID: guildID,
+		})
+		if err != nil {
+			return err
+		}
+		if groceryList == nil {
+			return echo.NewHTTPError(404, repositories.ErrGroceryListNotFound.Error())
+		}
+
+		groceryList.FancyName = req.FancyName
+		if err := groceryListRepo.WithContext(ctx).Save(groceryList); err != nil {
+			return err
+		}
+
+		if err := grocery.Service.OnGroceryListEdit(ctx, groceryList, guildID); err != nil {
+			logger.Error("Failed to update grohere after grocery list edit", zap.Error(err))
+		}
+
+		return c.JSON(200, groceryList)
 	})
 }

--- a/handlers/api/routegrocerylists/grocery_lists_handlers.go
+++ b/handlers/api/routegrocerylists/grocery_lists_handlers.go
@@ -56,7 +56,7 @@ func Register(
 		if err != nil {
 			return err
 		}
-		if existingCount >= int64(registrationContext.MaxGroceryListsPerServer) {
+		if existingCount+1 >= int64(registrationContext.MaxGroceryListsPerServer) {
 			return echo.NewHTTPError(400, fmt.Sprintf(
 				"You've reached the max number of grocery lists for this server (%d).",
 				registrationContext.MaxGroceryListsPerServer,

--- a/handlers/api/routegrocerylists/grocery_lists_handlers.go
+++ b/handlers/api/routegrocerylists/grocery_lists_handlers.go
@@ -1,0 +1,71 @@
+package routegrocerylists
+
+import (
+	"strconv"
+
+	"github.com/labstack/echo/v4"
+	"github.com/verzac/grocer-discord-bot/dto"
+	"github.com/verzac/grocer-discord-bot/handlers"
+	apimw "github.com/verzac/grocer-discord-bot/handlers/api/middleware"
+	"github.com/verzac/grocer-discord-bot/repositories"
+	"go.uber.org/zap"
+)
+
+// Register mounts /grocery-lists mutation routes (POST, DELETE /:id, PATCH /:id).
+// Not yet implemented — see handlers/grolist.go (newList, deleteList, editList).
+func Register(
+	e *echo.Echo,
+	logger *zap.Logger,
+	groceryListRepo repositories.GroceryListRepository,
+	groceryEntryRepo repositories.GroceryEntryRepository,
+) {
+	logger = logger.Named("grocery-lists")
+
+	e.POST("/grocery-lists", func(c echo.Context) error {
+		defer handlers.Recover(logger)
+		authContext := c.(*apimw.AuthContext)
+		_ = authContext.GuildID
+
+		req := dto.CreateGroceryListRequest{}
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(400, "Invalid request body.")
+		}
+		if err := c.Validate(&req); err != nil {
+			return echo.NewHTTPError(400, err.Error())
+		}
+
+		return echo.NewHTTPError(501, "Not implemented.")
+	})
+	e.DELETE("/grocery-lists/:id", func(c echo.Context) error {
+		defer handlers.Recover(logger)
+		authContext := c.(*apimw.AuthContext)
+		_ = authContext.GuildID
+
+		idStr := c.Param("id")
+		if _, err := strconv.ParseUint(idStr, 10, 64); err != nil {
+			return echo.NewHTTPError(400, "Invalid ID format.")
+		}
+
+		return echo.NewHTTPError(501, "Not implemented.")
+	})
+	e.PATCH("/grocery-lists/:id", func(c echo.Context) error {
+		defer handlers.Recover(logger)
+		authContext := c.(*apimw.AuthContext)
+		_ = authContext.GuildID
+
+		idStr := c.Param("id")
+		if _, err := strconv.ParseUint(idStr, 10, 64); err != nil {
+			return echo.NewHTTPError(400, "Invalid ID format.")
+		}
+
+		req := dto.UpdateGroceryListRequest{}
+		if err := c.Bind(&req); err != nil {
+			return echo.NewHTTPError(400, "Invalid request body.")
+		}
+		if err := c.Validate(&req); err != nil {
+			return echo.NewHTTPError(400, err.Error())
+		}
+
+		return echo.NewHTTPError(501, "Not implemented.")
+	})
+}

--- a/handlers/api/routes.go
+++ b/handlers/api/routes.go
@@ -115,7 +115,7 @@ func RegisterAndStart(logger *zap.Logger, db *gorm.DB, grobotVersion string, dis
 		}
 		return c.JSON(200, out)
 	})
-	routegrocerylists.Register(e, logger, groceryListRepo, groceryEntryRepo, grohereRecordRepo)
+	routegrocerylists.Register(e, logger, groceryListRepo, groceryEntryRepo, grohereRecordRepo, discordSess)
 	e.DELETE("/groceries", func(c echo.Context) error {
 		defer handlers.Recover(logger)
 		authContext := c.(*apimw.AuthContext)

--- a/handlers/api/routes.go
+++ b/handlers/api/routes.go
@@ -18,6 +18,7 @@ import (
 	"github.com/verzac/grocer-discord-bot/handlers"
 	apimw "github.com/verzac/grocer-discord-bot/handlers/api/middleware"
 	"github.com/verzac/grocer-discord-bot/handlers/api/routeauth"
+	"github.com/verzac/grocer-discord-bot/handlers/api/routegrocerylists"
 	"github.com/verzac/grocer-discord-bot/handlers/api/routeguilds"
 	"github.com/verzac/grocer-discord-bot/handlers/api/routetest"
 	"github.com/verzac/grocer-discord-bot/models"
@@ -92,6 +93,7 @@ func RegisterAndStart(logger *zap.Logger, db *gorm.DB, grobotVersion string, dis
 	}
 
 	e.GET("/metrics", groprometheus.PrometheusHandler())
+	// TODO move this to routegrocerylists - opted to not do it right now to keep diff small and easy to review
 	e.GET("/grocery-lists", func(c echo.Context) error {
 		defer handlers.Recover(logger)
 		authContext := c.(*apimw.AuthContext)
@@ -111,6 +113,7 @@ func RegisterAndStart(logger *zap.Logger, db *gorm.DB, grobotVersion string, dis
 		}
 		return c.JSON(200, out)
 	})
+	routegrocerylists.Register(e, logger, groceryListRepo, groceryEntryRepo)
 	e.DELETE("/groceries", func(c echo.Context) error {
 		defer handlers.Recover(logger)
 		authContext := c.(*apimw.AuthContext)

--- a/handlers/api/routes.go
+++ b/handlers/api/routes.go
@@ -36,6 +36,7 @@ var (
 	groceryEntryRepo      repositories.GroceryEntryRepository
 	guildRegistrationRepo repositories.GuildRegistrationRepository
 	groceryListRepo       repositories.GroceryListRepository
+	grohereRecordRepo     repositories.GrohereRecordRepository
 	apiClientRepo         repositories.ApiClientRepository
 	userSessionRepo       repositories.UserSessionRepository
 )
@@ -75,6 +76,7 @@ func RegisterAndStart(logger *zap.Logger, db *gorm.DB, grobotVersion string, dis
 
 	groceryEntryRepo = &repositories.GroceryEntryRepositoryImpl{DB: db}
 	groceryListRepo = &repositories.GroceryListRepositoryImpl{DB: db}
+	grohereRecordRepo = &repositories.GrohereRecordRepositoryImpl{DB: db}
 	guildRegistrationRepo = &repositories.GuildRegistrationRepositoryImpl{DB: db}
 	apiClientRepo = &repositories.ApiClientRepositoryImpl{DB: db}
 	userSessionRepo = &repositories.UserSessionRepositoryImpl{DB: db}
@@ -113,7 +115,7 @@ func RegisterAndStart(logger *zap.Logger, db *gorm.DB, grobotVersion string, dis
 		}
 		return c.JSON(200, out)
 	})
-	routegrocerylists.Register(e, logger, groceryListRepo, groceryEntryRepo)
+	routegrocerylists.Register(e, logger, groceryListRepo, groceryEntryRepo, grohereRecordRepo)
 	e.DELETE("/groceries", func(c echo.Context) error {
 		defer handlers.Recover(logger)
 		authContext := c.(*apimw.AuthContext)

--- a/handlers/api/routes.go
+++ b/handlers/api/routes.go
@@ -95,7 +95,7 @@ func RegisterAndStart(logger *zap.Logger, db *gorm.DB, grobotVersion string, dis
 	}
 
 	e.GET("/metrics", groprometheus.PrometheusHandler())
-	// TODO move this to routegrocerylists - opted to not do it right now to keep diff small and easy to review
+	// TODO move this to routegrocerylists eventually as it's a grocery list endpoint
 	e.GET("/grocery-lists", func(c echo.Context) error {
 		defer handlers.Recover(logger)
 		authContext := c.(*apimw.AuthContext)

--- a/handlers/grolist.go
+++ b/handlers/grolist.go
@@ -144,7 +144,7 @@ func (m *MessageHandlerContext) newList() error {
 		return m.onError(err)
 	}
 	maxGroceryListPerServer := m.getMaxGroceryListPerServer()
-	if existingCountInGuild >= int64(maxGroceryListPerServer) {
+	if existingCountInGuild+1 >= int64(maxGroceryListPerServer) {
 		m.logger.Info(
 			"maxGroceryListPerServer limit hit.",
 			zap.String("GuildID", m.commandContext.GuildID),
@@ -152,7 +152,7 @@ func (m *MessageHandlerContext) newList() error {
 		)
 		return m.reply(fmt.Sprintf(
 			":shopping_bags: Whoops, you already have the maximum of %d grocery lists for this server. Please delete one through `!grolist delete <list label>` to make room for new ones. Alternatively, you can use `!grolist edit-label` and `!grolist edit-name` to edit your grocery list (see `!grohelp` for more details).\n\nPS: You can get higher limits by supporting me on Patreon through `!grohelp` or `/grohelp`!",
-			maxGroceryListPerServer,
+			existingCountInGuild+1,
 		))
 	}
 	newGroceryList, err := m.groceryListRepo.CreateGroceryList(m.commandContext.GuildID, label, fancyName)

--- a/handlers/grolist.go
+++ b/handlers/grolist.go
@@ -1,14 +1,13 @@
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	"github.com/verzac/grocer-discord-bot/models"
 	"github.com/verzac/grocer-discord-bot/repositories"
 	groceryutils "github.com/verzac/grocer-discord-bot/utils/grocery"
-
-	"go.uber.org/zap"
 )
 
 const (
@@ -139,20 +138,18 @@ func (m *MessageHandlerContext) newList() error {
 	if len(splitArgs) >= 3 && splitArgs[2] != "" {
 		fancyName = splitArgs[2]
 	}
-	existingCountInGuild, err := m.groceryListRepo.Count(&models.GroceryList{GuildID: m.commandContext.GuildID})
+	limitOk, groceryListLimit, err := m.groceryService.ValidateGroceryListLimit(
+		context.Background(),
+		m.GetRegistrationContext(),
+		m.commandContext.GuildID,
+	)
 	if err != nil {
 		return m.onError(err)
 	}
-	maxGroceryListPerServer := m.getMaxGroceryListPerServer()
-	if existingCountInGuild+1 >= int64(maxGroceryListPerServer) {
-		m.logger.Info(
-			"maxGroceryListPerServer limit hit.",
-			zap.String("GuildID", m.commandContext.GuildID),
-			zap.Int("maxGroceryListPerServer", maxGroceryListPerServer),
-		)
+	if !limitOk {
 		return m.reply(fmt.Sprintf(
 			":shopping_bags: Whoops, you already have the maximum of %d grocery lists for this server. Please delete one through `!grolist delete <list label>` to make room for new ones. Alternatively, you can use `!grolist edit-label` and `!grolist edit-name` to edit your grocery list (see `!grohelp` for more details).\n\nPS: You can get higher limits by supporting me on Patreon through `!grohelp` or `/grohelp`!",
-			existingCountInGuild+1,
+			groceryListLimit,
 		))
 	}
 	newGroceryList, err := m.groceryListRepo.CreateGroceryList(m.commandContext.GuildID, label, fancyName)

--- a/handlers/grolist.go
+++ b/handlers/grolist.go
@@ -144,7 +144,7 @@ func (m *MessageHandlerContext) newList() error {
 		return m.onError(err)
 	}
 	maxGroceryListPerServer := m.getMaxGroceryListPerServer()
-	if existingCountInGuild+1 >= int64(maxGroceryListPerServer) {
+	if existingCountInGuild >= int64(maxGroceryListPerServer) {
 		m.logger.Info(
 			"maxGroceryListPerServer limit hit.",
 			zap.String("GuildID", m.commandContext.GuildID),
@@ -152,7 +152,7 @@ func (m *MessageHandlerContext) newList() error {
 		)
 		return m.reply(fmt.Sprintf(
 			":shopping_bags: Whoops, you already have the maximum of %d grocery lists for this server. Please delete one through `!grolist delete <list label>` to make room for new ones. Alternatively, you can use `!grolist edit-label` and `!grolist edit-name` to edit your grocery list (see `!grohelp` for more details).\n\nPS: You can get higher limits by supporting me on Patreon through `!grohelp` or `/grohelp`!",
-			existingCountInGuild+1,
+			maxGroceryListPerServer,
 		))
 	}
 	newGroceryList, err := m.groceryListRepo.CreateGroceryList(m.commandContext.GuildID, label, fancyName)

--- a/handlers/handler_context.go
+++ b/handlers/handler_context.go
@@ -380,10 +380,6 @@ func (m *MessageHandlerContext) GetRegistrationContext() *dto.RegistrationContex
 	return registrationContext
 }
 
-func (m *MessageHandlerContext) getMaxGroceryListPerServer() int {
-	return m.GetRegistrationContext().MaxGroceryListsPerServer
-}
-
 func toItemIndex(argStr string) (int, error) {
 	itemIndex, err := strconv.Atoi(argStr)
 	if err != nil {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -165,6 +165,7 @@ paths:
           schema:
             type: integer
             format: int64
+            minimum: 1
       responses:
         "204":
           description: The grocery list has been successfully deleted.
@@ -190,6 +191,7 @@ paths:
           schema:
             type: integer
             format: int64
+            minimum: 1
       requestBody:
         required: true
         content:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -128,6 +128,89 @@ paths:
           $ref: "#/components/responses/UnauthorizedError"
         "403":
           $ref: "#/components/responses/ForbiddenError"
+    post:
+      summary: POST Grocery List
+      description: "Create a new grocery list for your server."
+      parameters:
+        - $ref: "#/components/parameters/XGuildIDHeader"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateGroceryListRequest"
+      responses:
+        "201":
+          description: A new grocery list has been created.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroceryList"
+        "400":
+          description: Bearer requests require `X-Guild-ID`; validation failure, duplicate label, or list limit reached.
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+  /grocery-lists/{id}:
+    delete:
+      summary: DELETE Grocery List
+      description: "Delete a grocery list by its ID. The list must have no grocery entries."
+      parameters:
+        - $ref: "#/components/parameters/XGuildIDHeader"
+        - name: id
+          in: path
+          required: true
+          description: The ID of the grocery list to delete.
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "204":
+          description: The grocery list has been successfully deleted.
+        "400":
+          description: Bearer requests require `X-Guild-ID`; or invalid ID format.
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          description: Grocery list not found in this guild.
+        "409":
+          description: Grocery list still has grocery entries.
+    patch:
+      summary: PATCH Grocery List
+      description: "Update a grocery list's display name (`fancy_name`)."
+      parameters:
+        - $ref: "#/components/parameters/XGuildIDHeader"
+        - name: id
+          in: path
+          required: true
+          description: The ID of the grocery list to update.
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateGroceryListRequest"
+      responses:
+        "200":
+          description: The grocery list has been successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GroceryList"
+        "400":
+          description: Bearer requests require `X-Guild-ID`; or invalid ID format or request body.
+        "401":
+          $ref: "#/components/responses/UnauthorizedError"
+        "403":
+          $ref: "#/components/responses/ForbiddenError"
+        "404":
+          description: Grocery list not found in this guild.
   /groceries:
     delete:
       summary: BATCH DELETE Grocery Entries
@@ -331,6 +414,25 @@ components:
             type: integer
             minimum: 1
           description: Primary keys of grocery entries to delete (see GET /grocery-lists). Values are unsigned (positive integers). At most 300 IDs per request.
+    CreateGroceryListRequest:
+      type: object
+      required: [list_label]
+      properties:
+        list_label:
+          type: string
+          description: "The unique label used to refer to this grocery list in commands (e.g. `gro:amazon`)."
+        fancy_name:
+          type: string
+          nullable: true
+          description: Optional display name shown alongside the label.
+    UpdateGroceryListRequest:
+      type: object
+      required: [fancy_name]
+      properties:
+        fancy_name:
+          type: string
+          nullable: true
+          description: Display name for the grocery list. Send `null` to clear it.
     GroceryEntry:
       type: object
       description: Represents a grocery entry (e.g. added by /gro).

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -422,6 +422,8 @@ components:
       properties:
         list_label:
           type: string
+          minLength: 1
+          pattern: "^[a-zA-Z]+$"
           description: "The unique label used to refer to this grocery list in commands (e.g. `gro:amazon`)."
         fancy_name:
           type: string

--- a/services/grocery/interface.go
+++ b/services/grocery/interface.go
@@ -19,6 +19,7 @@ var (
 type GroceryService interface {
 	ValidateGroceryEntryLimit(ctx context.Context, registrationContext *dto.RegistrationContext, guildID string, newItemCount int) (limitOk bool, limit int, err error)
 	ValidateGroceryEntryLimitUsingTotalCount(ctx context.Context, registrationContext *dto.RegistrationContext, guildID string, totalItemCount int) (limitOk bool, limit int, err error)
+	ValidateGroceryListLimit(ctx context.Context, registrationContext *dto.RegistrationContext, guildID string) (limitOk bool, limit int, err error)
 	OnGroceryListEdit(ctx context.Context, groceryList *models.GroceryList, guildID string) error
 	DeleteGroceriesByIDs(ctx context.Context, guildID string, ids []uint) error
 	UpdateGuildGrohere(ctx context.Context, guildID string) error

--- a/services/grocery/validate_grocery_list_limit.go
+++ b/services/grocery/validate_grocery_list_limit.go
@@ -1,0 +1,30 @@
+package grocery
+
+import (
+	"context"
+
+	"github.com/verzac/grocer-discord-bot/dto"
+	"github.com/verzac/grocer-discord-bot/models"
+	"go.uber.org/zap"
+)
+
+func (s *GroceryServiceImpl) ValidateGroceryListLimit(ctx context.Context, registrationContext *dto.RegistrationContext, guildID string) (limitOk bool, limit int, err error) {
+	limit = registrationContext.MaxGroceryListsPerServer
+	existingNamedListCount, err := s.groceryListRepo.WithContext(ctx).Count(&models.GroceryList{GuildID: guildID})
+	if err != nil {
+		return false, limit, err
+	}
+
+	// Add one for the new named list and one for the implicit default list, which is not stored in grocery_lists.
+	totalListCount := int(existingNamedListCount) + 2
+	if totalListCount > limit {
+		s.logger.Warn("max grocery list limit exceeded.",
+			zap.String("guildID", guildID),
+			zap.Any("registrationContext", registrationContext),
+			zap.Int("Limit", limit),
+			zap.Int("TotalListCount", totalListCount),
+		)
+		return false, limit, nil
+	}
+	return true, limit, nil
+}


### PR DESCRIPTION
## Summary

- Implements all three scaffolded mutation endpoints for named grocery lists
- **POST `/grocery-lists`** — validates label format (letters only) and per-server list limit, creates and returns the new list (201)
- **DELETE `/grocery-lists/:id`** — guards against non-empty lists (409), cleans up orphaned `GrohereRecord` rows, updates grohere, returns 204
- **PATCH `/grocery-lists/:id`** — updates `fancy_name`, triggers `OnGroceryListEdit` for grohere sync, returns 200 with updated model
- Wires `grohereRecordRepo` into `routes.go` and threads it through to the handler package

## Test plan

- [ ] Integration tests added for all three endpoints (`go test -tags api ./e2e/api/...`)
- [ ] POST: happy path, read-back, duplicate label, invalid label format, missing label, list count limit reached
- [ ] DELETE: happy path + read-back, not found, non-empty list (409)
- [ ] PATCH: happy path, not found, missing `fancy_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Sv89qAdoXjsfajgwJHxF2